### PR TITLE
rewriteMessages receive path instead of AssetId

### DIFF
--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -20,7 +20,7 @@ class IntlMessageTransformer extends Transformer {
   apply(Transform transform) async {
     var content = await transform.primaryInput.readAsString();
     var id = transform.primaryInput.id;
-    var newContent = rewriteMessages(content, '$id');
+    var newContent = rewriteMessages(content, '${id.path}');
     transform.addOutput(new Asset.fromString(id, newContent));
   }
 }


### PR DESCRIPTION
While this might be a naive fix for #6 , it does seem to work on both Win and Linux systems.