### PR TITLE
Adds --output-file parameter

### DIFF
--- a/bin/extract_to_arb.dart
+++ b/bin/extract_to_arb.dart
@@ -17,10 +17,9 @@ import 'package:path/path.dart' as path;
 import 'package:intl_translation/extract_messages.dart';
 import 'package:intl_translation/src/intl_message.dart';
 
-var outputFilename = 'intl_messages.arb';
-
 main(List<String> args) {
   var targetDir;
+  var outputFilename;
   bool transformer;
   var parser = new ArgParser();
   var extraction = new MessageExtraction();
@@ -47,6 +46,10 @@ main(List<String> args) {
       defaultsTo: '.',
       callback: (value) => targetDir = value,
       help: 'Specify the output directory.');
+  parser.addOption("output-file",
+      defaultsTo: 'intl_messages.arb',
+      callback: (value) => outputFilename = value,
+      help: 'Specify the output file.');
   parser.parse(args);
   if (args.length == 0) {
     print('Accepts Dart files and produces $outputFilename');


### PR DESCRIPTION
Hello,
This allows to (re)generate an arb file with the desired name.
It's useful for automation, and also to avoid wrong locale detection from files called `intl_messages.arb` because it has an underscore.

It can be called for example `messages.arb` to avoid auto-detection, or `messages_en.arb` to force `en` locale.

I've let this value as the default for backward compatibility, 