### PR TITLE
ignore the src/ lint warning (implementation_imports)

### DIFF
--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -219,6 +219,7 @@ import 'dart:async';
 
 import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';
+// ignore: implementation_imports
 import 'package:$intlImportPath/src/intl_helpers.dart';
 
 """;


### PR DESCRIPTION
- add a comment to suppress a lint about importing from src/ directories (fix https://github.com/dart-lang/intl/issues/151)

@alan-knight 