### PR TITLE
Update generate_localized.dart

### DIFF
--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -152,11 +152,7 @@ import 'package:$intlImportPath/message_lookup_by_library.dart';
 $extraImports
 final messages = new MessageLookup();
 
-// ignore: unused_element
-final _keepAnalysisHappy = Intl.defaultLocale;
-
-// ignore: non_constant_identifier_names
-typedef MessageIfAbsent(String message_str, List args);
+typedef MessageIfAbsent(String messageStr, List args);
 
 class MessageLookup extends MessageLookupByLibrary {
   get localeName => '$locale';

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -147,6 +147,8 @@ class MessageGeneration {
 // messages from the main program should be duplicated here with the same
 // function name.
 
+// ignore_for_file: unused_import
+
 import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';
 $extraImports


### PR DESCRIPTION
Fix two analysis warnings:

```
unused_element: The top level variable '_keepAnalysisHappy' isn't used.
non_constant_identifier_names: Name non-constant identifiers using lowerCamelCase.
```

@alan-knight, these show up in Flutter user code, including in the examples for the flutter website (https://github.com/flutter/website/pull/1036).
