### PR TITLE
Prepare for release of 0.16.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+  * Allow message extraction to find messages from prefixed uses of Intl.
+
 ## 0.16.7
   * Allow message extraction to find messages in class field declarations
     and top-level declarations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
   * Allow message extraction to find messages from prefixed uses of Intl.
 
+## 0.16.8
+  * Move analyzer dependency up to 0.33.0
+
 ## 0.16.7
   * Allow message extraction to find messages in class field declarations
     and top-level declarations.

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -147,9 +147,13 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   bool looksLikeIntlMessage(MethodInvocation node) {
     const validNames = const ["message", "plural", "gender", "select"];
     if (!validNames.contains(node.methodName.name)) return false;
-    if (!(node.target is SimpleIdentifier)) return false;
-    SimpleIdentifier target = node.target;
-    return target.token.toString() == "Intl";
+    final target = node.target;
+    if (target is SimpleIdentifier) {
+      return target.token.toString() == 'Intl';
+    } else if (target is PrefixedIdentifier) {
+      return target.identifier.token.toString() == 'Intl';
+    }
+    return false;
   }
 
   Message _expectedInstance(String type) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.16.7
+version: 0.16.8
 author: Dart Team <misc@dartlang.org>
 description: Contains code to deal with internationalized/localized messages, date and number formatting and parsing, bi-directional text, and other internationalization issues.
 homepage: https://github.com/dart-lang/intl_translation
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.12.0 <2.0.0'
 documentation: http://www.dartdocs.org/documentation/intl_translation/latest
 dependencies:
-  analyzer: '>=0.29.1 <0.32.0'
+  analyzer: '>=0.29.1 <0.33.0'
   args: '>=0.12.1 <2.0.0'
   barback: ^0.15.2
   dart_style: ^1.0.0

--- a/test/message_extraction/find_messages_test.dart
+++ b/test/message_extraction/find_messages_test.dart
@@ -134,5 +134,17 @@ String message(String string) =>
           messages.map((m) => m.name), anyElement(contains('message string')));
       expect(messageExtraction.warnings, isEmpty);
     });
+
+    test('succeeds on prefixed Intl call', () {
+      final messageExtraction = new MessageExtraction();
+      final messages = findMessages('''
+      class MessageTest {
+        static final String prefixedMessage = prefix.Intl.message('message');
+      }
+      ''', '', messageExtraction);
+
+      expect(messages.map((m) => m.name), anyElement(contains('message')));
+      expect(messageExtraction.warnings, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
Move up to 0.16.8:
 * Allow message extraction to find messages from prefixed uses of Intl  …
 * Move analyzer dependency up to <0.33.0 