### PR TITLE
Add --suppress-last-modified option to suppress @@last_modified

### DIFF
--- a/bin/extract_to_arb.dart
+++ b/bin/extract_to_arb.dart
@@ -24,6 +24,10 @@ main(List<String> args) {
   var parser = new ArgParser();
   var extraction = new MessageExtraction();
   String locale;
+  parser.addFlag("suppress-last-modified",
+      defaultsTo: false,
+      callback: (x) => extraction.suppressLastModified = x,
+      help: 'Suppress @@last_modified entry.');
   parser.addFlag("suppress-warnings",
       defaultsTo: false,
       callback: (x) => extraction.suppressWarnings = x,
@@ -66,7 +70,9 @@ main(List<String> args) {
   if (locale != null) {
     allMessages["@@locale"] = locale;
   }
-  allMessages["@@last_modified"] = new DateTime.now().toIso8601String();
+  if (!extraction.suppressLastModified) {
+    allMessages["@@last_modified"] = new DateTime.now().toIso8601String();
+  }
   for (var arg in args.where((x) => x.contains(".dart"))) {
     var messages = extraction.parseFile(new File(arg), transformer);
     messages.forEach((k, v) => allMessages.addAll(toARB(v)));

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -36,6 +36,9 @@ class MessageExtraction {
   /// What to do when a message is encountered, defaults to [print].
   OnMessage onMessage = print;
 
+  /// If this is true, the @@last_modified entry is not output.
+  bool suppressLastModified = false;
+
   /// If this is true, print warnings for skipped messages. Otherwise, warnings
   /// are suppressed.
   bool suppressWarnings = false;


### PR DESCRIPTION
We re-run the ```flutter pub pub run intl_translation:extract_to_arb``` command frequently to ensure all messages have been extracted and find it inconvenient when the only line that changes is the "@@last_modified" flag.   We often revert this file back.

We'd prefer to strip the @@last_modified and use git to determine when things have actually changed.

Thus added a simple flag to suppress the output of the ```@@last_modified``` line.