### PR TITLE
suppress-meta-data flag

### DIFF
--- a/bin/extract_to_arb.dart
+++ b/bin/extract_to_arb.dart
@@ -32,6 +32,10 @@ main(List<String> args) {
       defaultsTo: false,
       callback: (x) => extraction.suppressWarnings = x,
       help: 'Suppress printing of warnings.');
+  parser.addFlag("suppress-meta-data",
+      defaultsTo: false,
+      callback: (x) => extraction.suppressMetaData = x,
+      help: 'Suppress writing meta information');
   parser.addFlag("warnings-are-errors",
       defaultsTo: false,
       callback: (x) => extraction.warningsAreErrors = x,
@@ -79,7 +83,7 @@ main(List<String> args) {
   }
   for (var arg in args.where((x) => x.contains(".dart"))) {
     var messages = extraction.parseFile(new File(arg), transformer);
-    messages.forEach((k, v) => allMessages.addAll(toARB(v)));
+    messages.forEach((k, v) => allMessages.addAll(toARB(v, extraction)));
   }
   var file = new File(path.join(targetDir, outputFilename));
   var encoder = new JsonEncoder.withIndent("  ");
@@ -100,11 +104,15 @@ String leaveTheInterpolationsInDartForm(MainMessage msg, chunk) {
 }
 
 /// Convert the [MainMessage] to a trivial JSON format.
-Map toARB(MainMessage message) {
+Map toARB(MainMessage message, MessageExtraction extraction) {
   if (message.messagePieces.isEmpty) return null;
   var out = {};
   out[message.name] = icuForm(message);
-  out["@${message.name}"] = arbMetadata(message);
+
+  if (!extraction.suppressMetaData) {
+    out["@${message.name}"] = arbMetadata(message);
+  }
+
   return out;
 }
 

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -43,6 +43,9 @@ class MessageExtraction {
   /// are suppressed.
   bool suppressWarnings = false;
 
+  /// If this is true, no translation meta data is written
+  bool suppressMetaData = false;
+
   /// If this is true, then treat all warnings as errors.
   bool warningsAreErrors = false;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.17.2
+version: 0.17.3-dev
 author: Dart Team <misc@dartlang.org>
 description: >-
   Contains code to deal with internationalized/localized messages,


### PR DESCRIPTION
Added command line flag `suppress-meta-data` to be able to generate an ARB file which only contains translation-relevant data (no meta data).