### PR TITLE
added dart-list as commandline parameter to extract_to_arb

### DIFF
--- a/bin/extract_to_arb.dart
+++ b/bin/extract_to_arb.dart
@@ -20,6 +20,7 @@ import 'package:intl_translation/src/intl_message.dart';
 main(List<String> args) {
   var targetDir;
   var outputFilename;
+  var dartFileList = null;
   bool transformer;
   var parser = new ArgParser();
   var extraction = new MessageExtraction();
@@ -62,6 +63,10 @@ main(List<String> args) {
       defaultsTo: 'intl_messages.arb',
       callback: (value) => outputFilename = value,
       help: 'Specify the output file.');
+  parser.addOption("dart-list",
+    defaultsTo: null,
+    callback: (value) => dartFileList = value,
+    help: 'Specify a file that contains the dart-files to read, one per line.');
   parser.addFlag("require_descriptions",
       defaultsTo: false,
       help: "Fail for messages that don't have a description.",
@@ -81,7 +86,19 @@ main(List<String> args) {
   if (!extraction.suppressLastModified) {
     allMessages["@@last_modified"] = new DateTime.now().toIso8601String();
   }
-  for (var arg in args.where((x) => x.contains(".dart"))) {
+
+  var dartFiles = args.where((x) => x.contains(".dart")).toList();
+  if(dartFileList != null)
+  {
+    File file = File(dartFileList);
+    if(file != null)
+    {
+      String content = file.readAsStringSync();
+      List<String> list = content.split("\r\n");
+      dartFiles.addAll(list.where((e) => e.isNotEmpty));
+    }
+  }
+  for (var arg in dartFiles) {
     var messages = extraction.parseFile(new File(arg), transformer);
     messages.forEach((k, v) => allMessages.addAll(toARB(v, extraction)));
   }
@@ -92,6 +109,11 @@ main(List<String> args) {
     exit(1);
   }
 }
+
+processLines(List<String> lines, var extraction)
+{
+}
+
 
 /// This is a placeholder for transforming a parameter substitution from
 /// the translation file format into a Dart interpolation. In our case we

--- a/bin/generate_from_arb.dart
+++ b/bin/generate_from_arb.dart
@@ -40,6 +40,8 @@ main(List<String> args) {
   var parser = new ArgParser();
   var extraction = new MessageExtraction();
   var generation = new MessageGeneration();
+  var dartFileList = null;
+  var arbFileList = null;
   var transformer;
   parser.addFlag('json', defaultsTo: false, callback: (useJson) {
     generation =
@@ -67,6 +69,14 @@ main(List<String> args) {
       defaultsTo: 'debug',
       callback: (x) => generation.codegenMode = x,
       help: 'What mode to run the code generator in. Either release or debug.');
+  parser.addOption("dart-list",
+    defaultsTo: null,
+    callback: (value) => dartFileList = value,
+    help: 'Specify a file that contains the dart-files to read, one per line.');
+  parser.addOption("arb-list",
+    defaultsTo: null,
+    callback: (value) => arbFileList = value,
+    help: 'Specify a file that contains the arb-files to process, one per line.');
   parser.addFlag("transformer",
       defaultsTo: false,
       callback: (x) => transformer = x,
@@ -76,6 +86,26 @@ main(List<String> args) {
   parser.parse(args);
   var dartFiles = args.where((x) => x.endsWith("dart")).toList();
   var jsonFiles = args.where((x) => x.endsWith(".arb")).toList();
+  if(dartFileList != null)
+  {
+    File file = File(dartFileList);
+    if(file != null)
+    {
+      String content = file.readAsStringSync();
+      List<String> list = content.split("\r\n");
+      dartFiles.addAll(list.where((e) => e.isNotEmpty));
+    }
+  }
+  if(arbFileList != null)
+  {
+    File file = File(arbFileList);
+    if(file != null)
+    {
+      String content = file.readAsStringSync();
+      List<String> list = content.split("\r\n");
+      jsonFiles.addAll(list.where((e) => e.isNotEmpty));
+    }
+  }
   if (dartFiles.length == 0 || jsonFiles.length == 0) {
     print('Usage: generate_from_arb [options]'
         ' file1.dart file2.dart ...'


### PR DESCRIPTION
In big projects the number of dart-files together with the number of languages can exceed the limit of 2047 chars for commandline parameters in DOS. So i added the commandline option to specify files that contain the list of dart-files (option --dart-list) and the list of arb-files (option --arb-list) which contain the list of the files. The file contains one filename per line (inclusive path) and is read as if the files were given in the command line. 