### PR TITLE
added --force-generate-name parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.17.8
+  * Added --force-generate-name to force extract_to_arb to generate
+    a class_method name in case the message does not provide one
+
 ## 0.17.7
   * Fixed the pubspec to allow intl version 0.16.*
 

--- a/bin/extract_to_arb.dart
+++ b/bin/extract_to_arb.dart
@@ -20,6 +20,7 @@ main(List<String> args) {
   var targetDir;
   var outputFilename;
   bool transformer;
+  bool forceGenerateName;
   var parser = new ArgParser();
   var extraction = new MessageExtraction();
   String locale;
@@ -49,6 +50,10 @@ main(List<String> args) {
       callback: (x) => transformer = x,
       help: "Assume that the transformer is in use, so name and args "
           "don't need to be specified for messages.");
+  parser.addFlag("force-generate-name",
+      defaultsTo: false,
+      callback: (x) => forceGenerateName = x,
+      help: 'Set the name based on the class and method name in case its not set manually');
   parser.addOption("locale",
       defaultsTo: null,
       callback: (value) => locale = value,
@@ -85,7 +90,7 @@ main(List<String> args) {
     allMessages["@@last_modified"] = new DateTime.now().toIso8601String();
   }
   for (var arg in args.where((x) => x.contains(".dart"))) {
-    var messages = extraction.parseFile(new File(arg), transformer);
+    var messages = extraction.parseFile(new File(arg), transformer, forceGenerateName);
     messages.forEach((k, v) => allMessages.addAll(toARB(v, extraction)));
   }
   var file = new File(path.join(targetDir, outputFilename));


### PR DESCRIPTION
added optional parameter to `extract_to_arb` called `force-generate-name` which forces a name generation (class_method) in case no name property is defined