### PR TITLE
add glob path parser

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: >-
 
 homepage: https://github.com/dart-lang/intl_translation
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   analyzer: '>=0.36.0 <0.40.0'
@@ -17,5 +17,6 @@ dependencies:
   intl: '>=0.15.3 <0.17.0'
   path: '>=0.9.0 <2.0.0'
   petitparser: '>=1.1.3 < 3.0.0'
+  glob: ^1.2.0
 dev_dependencies:
   test: ^1.2.0


### PR DESCRIPTION
I changed the path argument parser using glob for cross-platform and regexp matching. The changes are backward compatible.
And now you can use the following pattern in any OS and shell intepreters.
```shell
# use glob style, recommend!
flutter pub run intl_translation:extract_to_arb --output-dir=lib/l10n lib/**.dart
# use old style, maybe tredious and error-prone
flutter pub run intl_translation:extract_to_arb --output-dir=lib/l10n lib/localization.dart lib/app.dart

# use glob style, recommend!
flutter pub run intl_translation:generate_from_arb --output-dir=lib/l10n --no-use-deferred-loading lib/**.dart lib/l10n/intl_*.arb
# use old style, maybe tredious and error-prone
flutter pub run intl_translation:generate_from_arb --output-dir=lib/l10n --no-use-deferred-loading lib/localization.dart lib/app.dart lib/l10n/intl_messages.arb lib/l10n/intl_en.arb lib/l10n/intl_zh.arb

```