### PR TITLE
Allow to use MessageExtraction and MessageGeneration without dart:io

### DIFF
--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -87,18 +87,17 @@ class MessageExtraction {
     return parseContent(contents, file.path, transformer);
   }
 
-  /// Parse the source of the Dart program from a file with content 
-  /// [fileContent] and path [path] and return a Map from message 
+  /// Parse the source of the Dart program from a file with content
+  /// [fileContent] and path [path] and return a Map from message
   /// names to [IntlMessage] instances.
   ///
   /// If [transformer] is true, assume the transformer will supply any "name"
   /// and "args" parameters required in Intl.message calls.
   Map<String, MainMessage> parseContent(String fileContent, String filepath,
       [bool transformer = false]) {
-   
     String contents = fileContent;
     origin = filepath;
-     // Optimization to avoid parsing files we're sure don't contain any messages.
+    // Optimization to avoid parsing files we're sure don't contain any messages.
     if (contents.contains('Intl.')) {
       root = _parseCompilationUnit(contents, origin);
     } else {

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -85,7 +85,7 @@ class MessageExtraction {
   Map<String, MainMessage> parseFile(File file, [bool transformer = false]) {
     // Optimization to avoid parsing files we're sure don't contain any messages.
     String contents = file.readAsStringSync();
-    parseFileContent(contents, file.path, transformer);
+    return parseFileContent(contents, file.path, transformer);
   }
 
   /// Parse the source of the Dart program from a file with content [fileContent] and path [path]

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -85,7 +85,19 @@ class MessageExtraction {
   Map<String, MainMessage> parseFile(File file, [bool transformer = false]) {
     // Optimization to avoid parsing files we're sure don't contain any messages.
     String contents = file.readAsStringSync();
-    origin = file.path;
+    parseFileContent(contents, file.path, transformer);
+  }
+
+  /// Parse the source of the Dart program from a file with content [fileContent] and path [path]
+  /// and return a Map from message names to [IntlMessage] instances.
+  ///
+  /// If [transformer] is true, assume the transformer will supply any "name"
+  /// and "args" parameters required in Intl.message calls.
+  Map<String, MainMessage> parseFileContent(String fileContent, String filepath,
+      [bool transformer = false]) {
+    // Optimization to avoid parsing files we're sure don't contain any messages.
+    String contents = fileContent;
+    origin = filepath;
     if (contents.contains("Intl.")) {
       root = _parseCompilationUnit(contents, origin);
     } else {

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -83,22 +83,23 @@ class MessageExtraction {
   /// If [transformer] is true, assume the transformer will supply any "name"
   /// and "args" parameters required in Intl.message calls.
   Map<String, MainMessage> parseFile(File file, [bool transformer = false]) {
-    // Optimization to avoid parsing files we're sure don't contain any messages.
     String contents = file.readAsStringSync();
-    return parseFileContent(contents, file.path, transformer);
+    return parseContent(contents, file.path, transformer);
   }
 
-  /// Parse the source of the Dart program from a file with content [fileContent] and path [path]
-  /// and return a Map from message names to [IntlMessage] instances.
+  /// Parse the source of the Dart program from a file with content 
+  /// [fileContent] and path [path] and return a Map from message 
+  /// names to [IntlMessage] instances.
   ///
   /// If [transformer] is true, assume the transformer will supply any "name"
   /// and "args" parameters required in Intl.message calls.
-  Map<String, MainMessage> parseFileContent(String fileContent, String filepath,
+  Map<String, MainMessage> parseContent(String fileContent, String filepath,
       [bool transformer = false]) {
-    // Optimization to avoid parsing files we're sure don't contain any messages.
+   
     String contents = fileContent;
     origin = filepath;
-    if (contents.contains("Intl.")) {
+     // Optimization to avoid parsing files we're sure don't contain any messages.
+    if (contents.contains('Intl.')) {
       root = _parseCompilationUnit(contents, origin);
     } else {
       return {};

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -72,6 +72,7 @@ class MessageGeneration {
   /// for the [translations] in [locale] and put it in [targetDir].
   void generateIndividualMessageFile(String basicLocale,
       Iterable<TranslatedMessage> translations, String targetDir) {
+
     final content = contentForLocale(basicLocale, translations);
 
     // To preserve compatibility, we don't use the canonical version of the
@@ -85,6 +86,7 @@ class MessageGeneration {
   /// with the [translations] in [locale].
   String contentForLocale(
       String basicLocale, Iterable<TranslatedMessage> translations) {
+    
     clearOutput();
     var locale = new MainMessage()
         .escapeAndValidateString(Intl.canonicalizedLocale(basicLocale));

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -72,20 +72,19 @@ class MessageGeneration {
   /// for the [translations] in [locale] and put it in [targetDir].
   void generateIndividualMessageFile(String basicLocale,
       Iterable<TranslatedMessage> translations, String targetDir) {
-    final content = generateIndividualMessageFileContent(
-        basicLocale, translations);
+    final content = contentForLocale(basicLocale, translations);
 
     // To preserve compatibility, we don't use the canonical version of the
     // locale in the file name.
-    var filename = path.join(
-        targetDir, "${generatedFilePrefix}messages_$basicLocale.dart");
-    new File(filename).writeAsStringSync(content);
+    final filename = path.join(
+        targetDir, '${generatedFilePrefix}messages_$basicLocale.dart');
+    File(filename).writeAsStringSync(content);
   }
 
   /// Generate a string that containts the dart code
-  /// with the [tranlsations] in [locale].
-  String generateIndividualMessageFileContent(String basicLocale,
-      Iterable<TranslatedMessage> translations) {
+  /// with the [translations] in [locale].
+  String contentForLocale(
+      String basicLocale, Iterable<TranslatedMessage> translations) {
     clearOutput();
     var locale = new MainMessage()
         .escapeAndValidateString(Intl.canonicalizedLocale(basicLocale));
@@ -106,7 +105,7 @@ class MessageGeneration {
 
     writeTranslations(usableTranslations, locale);
 
-    return output.toString();
+    return '$output';
   }
 
   /// Write out the translated forms.

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -85,7 +85,6 @@ class MessageGeneration {
   /// with the [translations] in [locale].
   String contentForLocale(
       String basicLocale, Iterable<TranslatedMessage> translations) {
-    
     clearOutput();
     var locale = new MainMessage()
         .escapeAndValidateString(Intl.canonicalizedLocale(basicLocale));

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -72,7 +72,6 @@ class MessageGeneration {
   /// for the [translations] in [locale] and put it in [targetDir].
   void generateIndividualMessageFile(String basicLocale,
       Iterable<TranslatedMessage> translations, String targetDir) {
-
     final content = contentForLocale(basicLocale, translations);
 
     // To preserve compatibility, we don't use the canonical version of the

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -73,7 +73,7 @@ class MessageGeneration {
   void generateIndividualMessageFile(String basicLocale,
       Iterable<TranslatedMessage> translations, String targetDir) {
     final content = generateIndividualMessageFileContent(
-        basicLocale, translations, targetDir);
+        basicLocale, translations);
 
     // To preserve compatibility, we don't use the canonical version of the
     // locale in the file name.
@@ -85,7 +85,7 @@ class MessageGeneration {
   /// Generate a string that containts the dart code
   /// with the [tranlsations] in [locale].
   String generateIndividualMessageFileContent(String basicLocale,
-      Iterable<TranslatedMessage> translations, String targetDir) {
+      Iterable<TranslatedMessage> translations) {
     clearOutput();
     var locale = new MainMessage()
         .escapeAndValidateString(Intl.canonicalizedLocale(basicLocale));

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -72,6 +72,20 @@ class MessageGeneration {
   /// for the [translations] in [locale] and put it in [targetDir].
   void generateIndividualMessageFile(String basicLocale,
       Iterable<TranslatedMessage> translations, String targetDir) {
+    final content = generateIndividualMessageFileContent(
+        basicLocale, translations, targetDir);
+
+    // To preserve compatibility, we don't use the canonical version of the
+    // locale in the file name.
+    var filename = path.join(
+        targetDir, "${generatedFilePrefix}messages_$basicLocale.dart");
+    new File(filename).writeAsStringSync(content);
+  }
+
+  /// Generate a string that containts the dart code
+  /// with the [tranlsations] in [locale].
+  String generateIndividualMessageFileContent(String basicLocale,
+      Iterable<TranslatedMessage> translations, String targetDir) {
     clearOutput();
     var locale = new MainMessage()
         .escapeAndValidateString(Intl.canonicalizedLocale(basicLocale));
@@ -92,11 +106,7 @@ class MessageGeneration {
 
     writeTranslations(usableTranslations, locale);
 
-    // To preserve compatibility, we don't use the canonical version of the
-    // locale in the file name.
-    var filename = path.join(
-        targetDir, "${generatedFilePrefix}messages_$basicLocale.dart");
-    new File(filename).writeAsStringSync(output.toString());
+    return output.toString();
   }
 
   /// Write out the translated forms.


### PR DESCRIPTION
Currently, MessageExtraction and MessageGeneration depend on reading the file inside the class.

I am building the intl_translation_format at Google Summer of Code. It is an extension of this package to support multiple translation formats. For that, I am abstracting the File reading and writing for all the process.  

This PR adds `parseContent` to `MessageExtraction` and `contentForLocale` to `MessageGeneration` that allows to extract and generate a message from a string filename and the string content.


The work has already been reviewed by @alan-knight  at [#1 Draft Request](https://github.com/jamesblasco/intl_translation/pull/1)