### PR TITLE
Added a String return type to generated methods to satisfy pedantic lint rules.

### DIFF
--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -148,7 +148,7 @@ class MessageGeneration {
       // 24356
       """
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static _notInlinedMessages(_) => <String, Function> {
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function> {
 """;
 
   /// [generateIndividualMessageFile] for the beginning of the file,

--- a/lib/src/intl_message.dart
+++ b/lib/src/intl_message.dart
@@ -532,7 +532,7 @@ class MainMessage extends ComplexMessage {
   /// keyed by name with values the function that calls Intl.message.
   String toCodeForLocale(String locale, String name) {
     var out = new StringBuffer()
-      ..write('static $name(')
+      ..write('static String $name(')
       ..write(arguments.join(", "))
       ..write(') => "')
       ..write(translations[locale])


### PR DESCRIPTION
See https://dart-lang.github.io/linter/lints/always_declare_return_types.html