### PR TITLE
Changes as per pendatic analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ packages
 .idea/
 .pub/
 
+# ignoring .dart_tool created oin vs-code
+.dart_tool
+
 # Include when developing application packages.
 pubspec.lock

--- a/bin/extract_to_arb.dart
+++ b/bin/extract_to_arb.dart
@@ -22,10 +22,10 @@ main(List<String> args) {
   var outputFilename;
   String sourcesListFile;
   bool transformer;
-  var parser = new ArgParser();
-  var extraction = new MessageExtraction();
+  var parser = ArgParser();
+  var extraction = MessageExtraction();
   String locale;
-  parser.addFlag("suppress-last-modified",
+  parser.addFlag('suppress-last-modified',
       defaultsTo: false,
       callback: (x) => extraction.suppressLastModified = x,
       help: 'Suppress @@last_modified entry.');
@@ -89,13 +89,13 @@ main(List<String> args) {
     allMessages["@@locale"] = locale;
   }
   if (!extraction.suppressLastModified) {
-    allMessages["@@last_modified"] = new DateTime.now().toIso8601String();
+    allMessages["@@last_modified"] = DateTime.now().toIso8601String();
   }
 
   var dartFiles = args.where((x) => x.endsWith(".dart")).toList();
   dartFiles.addAll(linesFromFile(sourcesListFile));
   for (var arg in dartFiles) {
-    var messages = extraction.parseFile(new File(arg), transformer);
+    var messages = extraction.parseFile(File(arg), transformer);
     messages.forEach(
       (k, v) => allMessages.addAll(
         toARB(v,
@@ -104,8 +104,8 @@ main(List<String> args) {
       ),
     );
   }
-  var file = new File(path.join(targetDir, outputFilename));
-  var encoder = new JsonEncoder.withIndent("  ");
+  var file = File(path.join(targetDir, outputFilename));
+  var encoder = JsonEncoder.withIndent("  ");
   file.writeAsStringSync(encoder.convert(allMessages));
   if (extraction.hasWarnings && extraction.warningsAreErrors) {
     exit(1);

--- a/bin/generate_from_arb.dart
+++ b/bin/generate_from_arb.dart
@@ -36,17 +36,16 @@ Map<String, List<MainMessage>> messages;
 
 const jsonDecoder = const JsonCodec();
 
-main(List<String> args) {
+void main(List<String> args) {
   var targetDir;
-  var parser = new ArgParser();
-  var extraction = new MessageExtraction();
-  var generation = new MessageGeneration();
+  var parser = ArgParser();
+  var extraction = MessageExtraction();
+  var generation = MessageGeneration();
   String sourcesListFile;
   String translationsListFile;
   var transformer;
   parser.addFlag('json', defaultsTo: false, callback: (useJson) {
-    generation =
-        useJson ? new JsonMessageGeneration() : new MessageGeneration();
+    generation = useJson ? JsonMessageGeneration() : MessageGeneration();
   }, help: 'Generate translations as a JSON string rather than as functions.');
   parser.addFlag("suppress-warnings",
       defaultsTo: false,
@@ -109,10 +108,10 @@ main(List<String> args) {
   // for real projects we could provide a command-line flag to indicate which
   // sort of automated name we're using.
   extraction.suppressWarnings = true;
-  var allMessages = dartFiles
-      .map((each) => extraction.parseFile(new File(each), transformer));
+  var allMessages =
+      dartFiles.map((each) => extraction.parseFile(File(each), transformer));
 
-  messages = new Map();
+  messages = Map();
   for (var eachMap in allMessages) {
     eachMap.forEach(
         (key, value) => messages.putIfAbsent(key, () => []).add(value));
@@ -130,12 +129,12 @@ main(List<String> args) {
     generateLocaleFile(locale, data, targetDir, generation);
   });
 
-  var mainImportFile = new File(path.join(
+  var mainImportFile = File(path.join(
       targetDir, '${generation.generatedFilePrefix}messages_all.dart'));
   mainImportFile.writeAsStringSync(generation.generateMainImportFile());
 }
 
-loadData(String filename, Map<String, List<Map>> messagesByLocale,
+void loadData(String filename, Map<String, List<Map>> messagesByLocale,
     MessageGeneration generation) {
   var file = File(filename);
   var src = file.readAsStringSync();
@@ -148,8 +147,8 @@ loadData(String filename, Map<String, List<Map>> messagesByLocale,
     // my_file_fr.arb is locale "fr" or "file_fr".
     var name = path.basenameWithoutExtension(file.path);
     locale = name.split("_").skip(1).join("_");
-    print("No @@locale or _locale field found in $name, "
-        "assuming '$locale' based on the file name.");
+    print('No @@locale or _locale field found in $name, '
+        'assuming \'$locale\' based on the file name.');
   }
   messagesByLocale.putIfAbsent(locale, () => []).add(data);
   generation.allLocales.add(locale);
@@ -188,7 +187,7 @@ BasicTranslatedMessage recreateIntlObjects(String id, data) {
   if (parsed is LiteralString && parsed.string.isEmpty) {
     parsed = plainParser.parse(data).value;
   }
-  return new BasicTranslatedMessage(id, parsed);
+  return BasicTranslatedMessage(id, parsed);
 }
 
 /// A TranslatedMessage that just uses the name as the id and knows how to look
@@ -205,5 +204,5 @@ class BasicTranslatedMessage extends TranslatedMessage {
   List<MainMessage> _findOriginals() => originalMessages = messages[id];
 }
 
-final pluralAndGenderParser = new IcuParser().message;
-final plainParser = new IcuParser().nonIcuMessage;
+final pluralAndGenderParser = IcuParser().message;
+final plainParser = IcuParser().nonIcuMessage;

--- a/bin/make_examples_const.dart
+++ b/bin/make_examples_const.dart
@@ -11,7 +11,7 @@ import 'package:dart_style/dart_style.dart';
 import 'package:intl_translation/src/message_rewriter.dart';
 
 main(List<String> args) {
-  var parser = new ArgParser();
+  var parser = ArgParser();
   var rest = parser.parse(args).rest;
   if (rest.length == 0) {
     print('Accepts Dart file paths and rewrites the examples to be const '
@@ -21,17 +21,17 @@ main(List<String> args) {
     exit(0);
   }
 
-  var formatter = new DartFormatter();
+  var formatter = DartFormatter();
   for (var inputFile in rest) {
     var outputFile = inputFile;
-    var file = new File(inputFile);
+    var file = File(inputFile);
     var content = file.readAsStringSync();
     var newSource = rewriteMessages(content, '$file');
     if (content == newSource) {
       print('No changes to $outputFile');
     } else {
       print('Writing new source to $outputFile');
-      var out = new File(outputFile);
+      var out = File(outputFile);
       out.writeAsStringSync(formatter.format(newSource));
     }
   }
@@ -46,7 +46,7 @@ String rewriteMessages(String source, String sourceName) {
   var messages = findMessages(source, sourceName);
   messages.sort((a, b) => a.sourcePosition.compareTo(b.sourcePosition));
   var start = 0;
-  var newSource = new StringBuffer();
+  var newSource = StringBuffer();
   for (var message in messages) {
     if (message.examples != null) {
       newSource.write(source.substring(start, message.sourcePosition));
@@ -71,4 +71,4 @@ void rewrite(StringBuffer newSource, String source, int start, message) {
   }
 }
 
-final RegExp nonConstExamples = new RegExp('([\\n,]\\s+examples\: ){');
+final RegExp nonConstExamples = RegExp('([\\n,]\\s+examples\: ){');

--- a/bin/rewrite_intl_messages.dart
+++ b/bin/rewrite_intl_messages.dart
@@ -24,7 +24,7 @@ bool useStringSubstitution = true;
 bool replace = false;
 
 main(List<String> args) {
-  var parser = new ArgParser();
+  var parser = ArgParser();
   parser.addOption('output',
       defaultsTo: 'transformed_output.dart',
       callback: (x) => outputFileOption = x,
@@ -55,10 +55,10 @@ main(List<String> args) {
     exit(0);
   }
 
-  var formatter = new DartFormatter();
+  var formatter = DartFormatter();
   for (var inputFile in rest) {
     var outputFile = replace ? inputFile : outputFileOption;
-    var file = new File(inputFile);
+    var file = File(inputFile);
     var content = file.readAsStringSync();
     var newSource = rewriteMessages(content, '$file',
         useStringSubstitution: useStringSubstitution);
@@ -66,7 +66,7 @@ main(List<String> args) {
       print('No changes to $outputFile');
     } else {
       print('Writing new source to $outputFile');
-      var out = new File(outputFile);
+      var out = File(outputFile);
       out.writeAsStringSync(formatter.format(newSource));
     }
   }

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -103,7 +103,7 @@ class MessageExtraction {
     } else {
       return {};
     }
-    var visitor = new MessageFindingVisitor(this);
+    var visitor = MessageFindingVisitor(this);
     visitor.generateNameAndArgs = transformer;
     root.accept(visitor);
     return visitor.messages;
@@ -131,7 +131,7 @@ class MessageExtraction {
   String origin;
 
   String _reportErrorLocation(AstNode node) {
-    var result = new StringBuffer();
+    var result = StringBuffer();
     if (origin != null) result.write("    from $origin");
     var info = root.lineInfo;
     if (info != null) {
@@ -154,7 +154,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   final MessageExtraction extraction;
 
   /// Accumulates the messages we have found, keyed by name.
-  final Map<String, MainMessage> messages = new Map<String, MainMessage>();
+  final Map<String, MainMessage> messages = Map<String, MainMessage>();
 
   /// Should we generate the name and arguments from the function definition,
   /// meaning we're running in the transformer.
@@ -287,7 +287,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
 
     if (reason != null) {
       if (!extraction.suppressWarnings) {
-        var err = new StringBuffer()
+        var err = StringBuffer()
           ..write("Skipping invalid Intl.message invocation\n    <$node>\n")
           ..writeAll(
               ["    reason: $reason\n", extraction._reportErrorLocation(node)]);
@@ -361,7 +361,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
       MainMessage extract(MainMessage message, List<AstNode> arguments),
       void setAttribute(
           MainMessage message, String fieldName, Object fieldValue)) {
-    var message = new MainMessage();
+    var message = MainMessage();
     message.sourcePosition = node.offset;
     message.endPosition = node.end;
     message.arguments =
@@ -373,7 +373,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
     for (var namedArgument in arguments.whereType<NamedExpression>()) {
       var name = namedArgument.name.label.name;
       var exp = namedArgument.expression;
-      var evaluator = new ConstantEvaluator();
+      var evaluator = ConstantEvaluator();
       var basicValue = exp.accept(evaluator);
       var value = basicValue == ConstantEvaluator.NOT_A_CONSTANT
           ? exp.toString()
@@ -402,7 +402,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   /// Find the message pieces from a Dart interpolated string.
   List _extractFromIntlCallWithInterpolation(
       MainMessage message, List<AstNode> arguments) {
-    var interpolation = new InterpolationVisitor(message, extraction);
+    var interpolation = InterpolationVisitor(message, extraction);
     arguments.first.accept(interpolation);
     if (interpolation.pieces.any((x) => x is Plural || x is Gender) &&
         !extraction.allowEmbeddedPluralsAndGenders) {
@@ -429,7 +429,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
         message.addPieces(extracted);
       } on IntlMessageExtractionException catch (e) {
         message = null;
-        var err = new StringBuffer()
+        var err = StringBuffer()
           ..writeAll(["Error ", e, "\nProcessing <", node, ">\n"])
           ..write(extraction._reportErrorLocation(node));
         var errString = err.toString();
@@ -451,8 +451,8 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   /// and the parameters to the Intl.plural or Intl.gender call.
   MainMessage messageFromDirectPluralOrGenderCall(MethodInvocation node) {
     MainMessage extractFromPluralOrGender(MainMessage message, _) {
-      var visitor = new PluralAndGenderVisitor(
-          message.messagePieces, message, extraction);
+      var visitor =
+          PluralAndGenderVisitor(message.messagePieces, message, extraction);
       node.accept(visitor);
       return message;
     }
@@ -516,7 +516,7 @@ class InterpolationVisitor extends SimpleAstVisitor {
   }
 
   void lookForPluralOrGender(InterpolationExpression node) {
-    var visitor = new PluralAndGenderVisitor(pieces, message, extraction);
+    var visitor = PluralAndGenderVisitor(pieces, message, extraction);
     node.accept(visitor);
     if (!visitor.foundPluralOrGender) {
       throw new IntlMessageExtractionException(
@@ -600,13 +600,13 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
     var message;
     switch (node.methodName.name) {
       case "gender":
-        message = new Gender();
+        message = Gender();
         break;
       case "plural":
-        message = new Plural();
+        message = Plural();
         break;
       case "select":
-        message = new Select();
+        message = Select();
         break;
       default:
         throw new IntlMessageExtractionException(
@@ -618,7 +618,7 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
     var arguments = message.argumentsOfInterestFor(node);
     arguments.forEach((key, value) {
       try {
-        var interpolation = new InterpolationVisitor(message, extraction);
+        var interpolation = InterpolationVisitor(message, extraction);
         value.accept(interpolation);
         // Might be null due to previous errors.
         // Continue collecting errors, but don't build message.
@@ -627,7 +627,7 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
         }
       } on IntlMessageExtractionException catch (e) {
         message = null;
-        var err = new StringBuffer()
+        var err = StringBuffer()
           ..writeAll(["Error ", e, "\nProcessing <", node, ">"])
           ..write(extraction._reportErrorLocation(node));
         var errString = err.toString();
@@ -642,7 +642,7 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
     } else if (mainArg is SimpleIdentifier) {
       message.mainArgument = mainArg.name;
     } else {
-      var err = new StringBuffer()
+      var err = StringBuffer()
         ..write("Error (Invalid argument to plural/gender/select, "
             "must be simple variable reference) "
             "\nProcessing <$node>")

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -134,7 +134,7 @@ class MessageGeneration {
             .toList()
               ..sort((a, b) => a.name.compareTo(b.name)))
         .map((original) =>
-            '    "${original.escapeAndValidateString(original.name)}" '
+            '    \'${original.escapeAndValidateString(original.name)}\' '
             ': ${_mapReference(original, locale)}');
     output..write(entries.join(",\n"))..write("\n  };\n}\n");
   }
@@ -477,8 +477,8 @@ bool _hasArguments(MainMessage message) => message.arguments.length != 0;
 String _mapReference(MainMessage original, String locale) {
   if (!_hasArguments(original)) {
     // No parameters, can be printed simply.
-    return 'MessageLookupByLibrary.simpleMessage("'
-        '${original.translations[locale]}")';
+    return 'MessageLookupByLibrary.simpleMessage(\''
+        '${original.translations[locale]}\')';
   } else {
     return _methodNameFor(original.name);
   }

--- a/test/message_extraction/embedded_plural_text_after.dart
+++ b/test/message_extraction/embedded_plural_text_after.dart
@@ -10,4 +10,6 @@ import "package:intl/intl.dart";
 
 embeddedPlural2(n) => Intl.message(
     "${Intl.plural(n, zero: 'none', one: 'one', other: 'some')} plus text.",
-    name: 'embeddedPlural2', desc: 'An embedded plural', args: [n]);
+    name: 'embeddedPlural2',
+    desc: 'An embedded plural',
+    args: [n]);

--- a/test/message_extraction/embedded_plural_text_before.dart
+++ b/test/message_extraction/embedded_plural_text_before.dart
@@ -10,4 +10,6 @@ import "package:intl/intl.dart";
 
 embeddedPlural(n) => Intl.message(
     "There are ${Intl.plural(n, zero: 'nothing', one: 'one', other: 'some')}.",
-    name: 'embeddedPlural', desc: 'An embedded plural', args: [n]);
+    name: 'embeddedPlural',
+    desc: 'An embedded plural',
+    args: [n]);

--- a/test/message_extraction/find_messages_test.dart
+++ b/test/message_extraction/find_messages_test.dart
@@ -90,7 +90,7 @@ String message(String string) =>
       final messageExtraction = new MessageExtraction();
       var messages = findMessages(
           'List<String> list = [Intl.message("message string", '
-          'name: "list", desc: "in list")];',
+              'name: "list", desc: "in list")];',
           '',
           messageExtraction);
 

--- a/test/message_extraction/part_of_sample_with_messages.dart
+++ b/test/message_extraction/part_of_sample_with_messages.dart
@@ -35,10 +35,7 @@ class YouveGotMessages {
   }
 
   plurals(num) => Intl.message(
-      """${Intl.plural(num,
-          zero: 'Is zero plural?',
-          one: 'This is singular.',
-          other: 'This is plural ($num).')}""",
+      """${Intl.plural(num, zero: 'Is zero plural?', one: 'This is singular.', other: 'This is plural ($num).')}""",
       name: "plurals",
       args: [num],
       desc: "Basic plurals");
@@ -48,10 +45,7 @@ class YouveGotMessages {
 
   whereTheyWentMessage(String name, String gender, String place) {
     return Intl.message(
-        "${Intl.gender(gender,
-            male: '$name went to his $place',
-            female: '$name went to her $place',
-            other: '$name went to its $place')}",
+        "${Intl.gender(gender, male: '$name went to his $place', female: '$name went to her $place', other: '$name went to its $place')}",
         name: "whereTheyWentMessage",
         args: [name, gender, place],
         desc: 'A person went to some place that they own, e.g. their room');
@@ -66,14 +60,7 @@ class YouveGotMessages {
     if (number == 0) combinedGender = "other";
 
     nestedMessage(names, number, combinedGender, place) => Intl.message(
-        '''${Intl.gender(combinedGender,
-            other: '${Intl.plural(number,
-                zero: "Personne n'est allé au $place",
-                one: "${names} est allé au $place",
-                other: "${names} sont allés au $place")}',
-            female: '${Intl.plural(number,
-                one: "$names est allée au $place",
-                other: "$names sont allées au $place")}')}''',
+        '''${Intl.gender(combinedGender, other: '${Intl.plural(number, zero: "Personne n'est allé au $place", one: "${names} est allé au $place", other: "${names} sont allés au $place")}', female: '${Intl.plural(number, one: "$names est allée au $place", other: "$names sont allées au $place")}')}''',
         desc: "Nested message example",
         name: "nestedMessage",
         args: [names, number, combinedGender, place]);


### PR DESCRIPTION
Removed **new** as we don't need it in new versions of dart.

Also changed **"** --> **'** 
      "aboutUs": MessageLookupByLibrary.simpleMessage("About Us"),
**changes to:**
      'aboutUs': MessageLookupByLibrary.simpleMessage('About Us'),

( because when the messages_en.dart file is generates then it does not follows the pendatic which makes it difficult to remove too much warnings caused by the analyzer ).

Code clean up with:  **dartfmt -w .**