### PR TITLE
Update intl constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   analyzer: '>=0.39.12 <0.40.0'
   args: '>=0.12.1 <2.0.0'
   dart_style: ^1.0.0
-  intl: '>=0.15.3 <0.17.0'
+  intl: ^0.16.1
   path: '>=0.9.0 <2.0.0'
   petitparser: ^3.0.0
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   analyzer: '>=0.39.12 <0.40.0'
   args: '>=0.12.1 <2.0.0'
   dart_style: ^1.0.0
-  intl: ^0.16.1
+  intl: ^0.17.0-nullsafety.2
   path: '>=0.9.0 <2.0.0'
   petitparser: ^3.0.0
 dev_dependencies:


### PR DESCRIPTION
On latest Flutter `master` version (`1.24.0-8.0.pre.194, revision 018467cdb1`), running `flutter pub get` fails with the following message:

```
Because <elided> depends on flutter_localizations any from sdk which depends on intl 0.17.0-nullsafety.2, intl 0.17.0-nullsafety.2 is required.
So, because <elided> depends on intl ^0.16.1, version solving failed.
```

So, bumping `intl` to `0.17.0-nullsafety.2` leads to the following message:

```
Because intl_translation >=0.17.7 depends on intl >=0.15.3 <0.17.0 and <elided> depends on intl ^0.17.0-nullsafety.2, intl_translation >=0.17.7 is forbidden.
So, because <elided> depends on intl_translation ^0.17.10+1, version solving failed.
pub upgrade failed (1; So, because <elided> depends on intl_translation ^0.17.10+1, version solving failed.)
```

This PR looses the constraints on `intl` so it can be used with latest Flutter `master` version.