### PR TITLE
Improve generated files for null-safe environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.17.10+2
+* Allow generated code to be used in null-safe environment
+
 ## 0.17.10+1
   * Generate code that passes analysis with `implicit-casts: false`.
   * Allow use of `MessageExtraction` and `MessageGeneration` without `File`.

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -148,13 +148,14 @@ class MessageGeneration {
       // 24356
       """
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static _notInlinedMessages(_) => <String, Function> {
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function> {
 """;
 
   /// [generateIndividualMessageFile] for the beginning of the file,
   /// parameterized by [locale].
   String prologue(String locale) =>
       """
+//@dart=2.7
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that provides messages for a $locale locale. All the
 // messages from the main program should be duplicated here with the same
@@ -238,6 +239,7 @@ class MessageLookup extends MessageLookupByLibrary {
   /// Constant string used in [generateMainImportFile] for the beginning of the
   /// file.
   get mainPrologue => """
+//@dart=2.7
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.17.10+1
+version: 0.17.10+2
 author: Dart Team <misc@dartlang.org>
 description: >-
   Contains code to deal with internationalized/localized messages,


### PR DESCRIPTION
Annotating the generated source files with a dart version string allows using the generated code in migrated contexts.

This is a quick fix until a proper null_safe version comes along.