### PR TITLE
Fixes duplicated entries on the generated message map.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 build/
 .packages
 packages
+.dart_tool/
 
 # Or the files created by dart2js.
 *.dart.js

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -135,7 +135,8 @@ class MessageGeneration {
               ..sort((a, b) => a.name.compareTo(b.name)))
         .map((original) =>
             '    "${original.escapeAndValidateString(original.name)}" '
-            ': ${_mapReference(original, locale)}');
+            ': ${_mapReference(original, locale)}')
+        .toSet();
     output..write(entries.join(",\n"))..write("\n  };\n}\n");
   }
 

--- a/test/duplicate_messages/duplicated_messages_test.dart
+++ b/test/duplicate_messages/duplicated_messages_test.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../../bin/extract_to_arb.dart' as extract;
+import '../../bin/generate_from_arb.dart' as generate;
+
+void main() {
+  test('Should generate unique message map', () async {
+    _generateArb('messages_pt');
+    _generateArb('messages_en');
+
+    var files = ['messages_pt', 'messages_en'];
+    _generateMessages(files);
+    await _assert('greet', files);
+  });
+}
+
+const testFolder = 'test/duplicate_messages';
+const outputFolder = '$testFolder/output';
+final currDir = Directory.current.absolute.path;
+
+void _generateArb(String fileName) {
+  extract.main([
+    '--output-file',
+    './$outputFolder/$fileName.arb',
+    './$testFolder/$fileName.dart'
+  ]);
+}
+
+void _generateMessages(List<String> files) {
+  final fileArgs = files.expand((file) => [
+        './$testFolder/$file.dart',
+        './$outputFolder/$file.arb',
+      ]);
+
+  generate.main([
+    '--output-dir',
+    outputFolder,
+    ...fileArgs,
+  ]);
+}
+
+void _assert(String key, List<String> files) async {
+  for (final element in files.map((e) => '$currDir/$outputFolder/$e')) {
+    final file = File("$element.dart");
+    final fileLines = await file.readAsLines();
+    final linesWithKey = fileLines
+        .map((e) => e.trimLeft())
+        .where((element) => element.startsWith("\"$key\" :"))
+        .length;
+    expect(linesWithKey, 1, reason: 'File $file has duplicated keys');
+  }
+}

--- a/test/duplicate_messages/messages_en.dart
+++ b/test/duplicate_messages/messages_en.dart
@@ -1,0 +1,5 @@
+import 'package:intl/intl.dart';
+
+class MessagesEn {
+  String get greet => Intl.message('Hello', name: 'greet');
+}

--- a/test/duplicate_messages/messages_pt.dart
+++ b/test/duplicate_messages/messages_pt.dart
@@ -1,0 +1,5 @@
+import 'package:intl/intl.dart';
+
+class MessagesPt {
+  String get greet => Intl.message('Olá', name: 'greet');
+}

--- a/test/duplicate_messages/output/.gitignore
+++ b/test/duplicate_messages/output/.gitignore
@@ -1,0 +1,2 @@
+# Forces git directory creation
+*.*


### PR DESCRIPTION
Fixes an issue that duplicates the translation map entries if the `Intl.message` calls are repeated across dart input files.

This is pretty much [this](https://github.com/dart-lang/intl_translation/pull/60) with test cases.
fixes #47 