### PR TITLE
Several linting upgrades for this package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * Add support for Flutter locale split.
   * Allow null safe code when parsing.
   * Update analyzer dependency.
+  * Upgrade to `package:lints/recommended.yaml`.
 
 ## 0.17.10+1
   * Generate code that passes analysis with `implicit-casts: false`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,10 +1,20 @@
-include: package:lints/core.yaml
+include: package:lints/recommended.yaml
+
+analyzer:
+  errors:
+    # Challenging with the file name patterns that this package generates.
+    file_names: ignore
+    # Preexisting violations.
+    unnecessary_getters_setters: ignore
 
 linter:
   rules:
-    # Disable requiring lowercase_with_underscore file names.
-    file_names: false
-
     # Enable some additional lints.
-    directives_ordering: true
-    sort_pub_dependencies: true
+    - always_declare_return_types
+    - directives_ordering
+    - prefer_single_quotes
+    - sort_pub_dependencies
+    - type_annotate_public_apis
+
+    # This is currently challenging for this package.
+    # - avoid_dynamic_calls

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,8 +4,8 @@ analyzer:
   errors:
     # Challenging with the file name patterns that this package generates.
     file_names: ignore
-    # Preexisting violations.
-    unnecessary_getters_setters: ignore
+    # This can cause issues with recognizing localizable strings.
+    unnecessary_string_interpolations: ignore
 
 linter:
   rules:

--- a/bin/extract_to_arb.dart
+++ b/bin/extract_to_arb.dart
@@ -17,13 +17,13 @@ import 'package:intl_translation/src/arb_generation.dart';
 import 'package:intl_translation/src/directory_utils.dart';
 import 'package:path/path.dart' as path;
 
-main(List<String> args) {
+void main(List<String> args) {
   String targetDir;
   String outputFilename;
   String sourcesListFile;
   bool transformer;
-  var parser = new ArgParser();
-  var extraction = new MessageExtraction();
+  var parser = ArgParser();
+  var extraction = MessageExtraction();
   String locale;
   parser.addFlag("suppress-last-modified",
       defaultsTo: false,
@@ -89,13 +89,13 @@ main(List<String> args) {
     allMessages["@@locale"] = locale;
   }
   if (!extraction.suppressLastModified) {
-    allMessages["@@last_modified"] = new DateTime.now().toIso8601String();
+    allMessages["@@last_modified"] = DateTime.now().toIso8601String();
   }
 
   var dartFiles = args.where((x) => x.endsWith(".dart")).toList();
   dartFiles.addAll(linesFromFile(sourcesListFile));
   for (var arg in dartFiles) {
-    var messages = extraction.parseFile(new File(arg), transformer);
+    var messages = extraction.parseFile(File(arg), transformer);
     messages.forEach(
       (k, v) => allMessages.addAll(
         toARB(v,
@@ -104,8 +104,8 @@ main(List<String> args) {
       ),
     );
   }
-  var file = new File(path.join(targetDir, outputFilename));
-  var encoder = new JsonEncoder.withIndent("  ");
+  var file = File(path.join(targetDir, outputFilename));
+  var encoder = JsonEncoder.withIndent("  ");
   file.writeAsStringSync(encoder.convert(allMessages));
   if (extraction.hasWarnings && extraction.warningsAreErrors) {
     exit(1);

--- a/bin/extract_to_arb.dart
+++ b/bin/extract_to_arb.dart
@@ -25,54 +25,54 @@ void main(List<String> args) {
   var parser = ArgParser();
   var extraction = MessageExtraction();
   String locale;
-  parser.addFlag("suppress-last-modified",
+  parser.addFlag('suppress-last-modified',
       defaultsTo: false,
       callback: (x) => extraction.suppressLastModified = x,
       help: 'Suppress @@last_modified entry.');
-  parser.addFlag("suppress-warnings",
+  parser.addFlag('suppress-warnings',
       defaultsTo: false,
       callback: (x) => extraction.suppressWarnings = x,
       help: 'Suppress printing of warnings.');
-  parser.addFlag("suppress-meta-data",
+  parser.addFlag('suppress-meta-data',
       defaultsTo: false,
       callback: (x) => extraction.suppressMetaData = x,
       help: 'Suppress writing meta information');
-  parser.addFlag("warnings-are-errors",
+  parser.addFlag('warnings-are-errors',
       defaultsTo: false,
       callback: (x) => extraction.warningsAreErrors = x,
       help: 'Treat all warnings as errors, stop processing ');
-  parser.addFlag("embedded-plurals",
+  parser.addFlag('embedded-plurals',
       defaultsTo: true,
       callback: (x) => extraction.allowEmbeddedPluralsAndGenders = x,
       help: 'Allow plurals and genders to be embedded as part of a larger '
           'string, otherwise they must be at the top level.');
-  parser.addFlag("transformer",
+  parser.addFlag('transformer',
       defaultsTo: false,
       callback: (x) => transformer = x,
-      help: "Assume that the transformer is in use, so name and args "
+      help: 'Assume that the transformer is in use, so name and args '
           "don't need to be specified for messages.");
-  parser.addOption("locale",
+  parser.addOption('locale',
       defaultsTo: null,
       callback: (value) => locale = value,
       help: 'Specify the locale set inside the arb file.');
-  parser.addFlag("with-source-text",
+  parser.addFlag('with-source-text',
       defaultsTo: false,
       callback: (x) => extraction.includeSourceText = x,
       help: 'Include source_text in meta information.');
-  parser.addOption("output-dir",
+  parser.addOption('output-dir',
       defaultsTo: '.',
       callback: (value) => targetDir = value,
       help: 'Specify the output directory.');
-  parser.addOption("output-file",
+  parser.addOption('output-file',
       defaultsTo: 'intl_messages.arb',
       callback: (value) => outputFilename = value,
       help: 'Specify the output file.');
-  parser.addOption("sources-list-file",
+  parser.addOption('sources-list-file',
       callback: (value) => sourcesListFile = value,
       help: 'A file that lists the Dart files to read, one per line.'
           'The paths in the file can be absolute or relative to the '
           'location of this file.');
-  parser.addFlag("require_descriptions",
+  parser.addFlag('require_descriptions',
       defaultsTo: false,
       help: "Fail for messages that don't have a description.",
       callback: (val) => extraction.descriptionRequired = val);
@@ -86,13 +86,13 @@ void main(List<String> args) {
   }
   var allMessages = {};
   if (locale != null) {
-    allMessages["@@locale"] = locale;
+    allMessages['@@locale'] = locale;
   }
   if (!extraction.suppressLastModified) {
-    allMessages["@@last_modified"] = DateTime.now().toIso8601String();
+    allMessages['@@last_modified'] = DateTime.now().toIso8601String();
   }
 
-  var dartFiles = args.where((x) => x.endsWith(".dart")).toList();
+  var dartFiles = args.where((x) => x.endsWith('.dart')).toList();
   dartFiles.addAll(linesFromFile(sourcesListFile));
   for (var arg in dartFiles) {
     var messages = extraction.parseFile(File(arg), transformer);
@@ -105,7 +105,7 @@ void main(List<String> args) {
     );
   }
   var file = File(path.join(targetDir, outputFilename));
-  var encoder = JsonEncoder.withIndent("  ");
+  var encoder = JsonEncoder.withIndent('  ');
   file.writeAsStringSync(encoder.convert(allMessages));
   if (extraction.hasWarnings && extraction.warningsAreErrors) {
     exit(1);

--- a/bin/generate_from_arb.dart
+++ b/bin/generate_from_arb.dart
@@ -84,6 +84,10 @@ main(List<String> args) {
       callback: (x) => generation.useDeferredLoading = x,
       help: 'Generate message code that must be loaded with deferred loading. '
           'Otherwise, all messages are eagerly loaded.');
+  parser.addFlag('null-safety',
+      defaultsTo: true,
+      callback: (val) => generation.nullSafety = val,
+      help: 'Generate null safe code vs legacy (pre-null safe) code.');
   parser.addOption('codegen_mode',
       allowed: ['release', 'debug'],
       defaultsTo: 'debug',

--- a/bin/generate_from_arb.dart
+++ b/bin/generate_from_arb.dart
@@ -208,7 +208,7 @@ void loadData(String filename, Map<String, List<Map>> messagesByLocale,
 void generateLocaleFile(String locale, List<Map> localeData, String targetDir,
     MessageGeneration generation) {
   List<TranslatedMessage> translations = [];
-  for (var jsonTranslations in localeData) {
+  for (/*Map<String, String>*/ var jsonTranslations in localeData) {
     jsonTranslations.forEach((id, messageData) {
       TranslatedMessage message = recreateIntlObjects(id, messageData);
       if (message != null) {
@@ -223,7 +223,7 @@ void generateLocaleFile(String locale, List<Map> localeData, String targetDir,
 /// things that are messages, we expect [id] not to start with "@" and
 /// [data] to be a String. For metadata we expect [id] to start with "@"
 /// and [data] to be a Map or null. For metadata we return null.
-BasicTranslatedMessage recreateIntlObjects(String id, data) {
+BasicTranslatedMessage recreateIntlObjects(String id, String data) {
   if (id.startsWith('@')) return null;
   if (data == null) return null;
   var parsed = pluralAndGenderParser.parse(data).value;

--- a/bin/generate_from_arb.dart
+++ b/bin/generate_from_arb.dart
@@ -67,7 +67,7 @@ void main(List<String> args) {
       hide: true,
       help: 'Customize the flutter import path, used for testing. Defaults to '
           'package:flutter.');
-  parser.addFlag("suppress-warnings",
+  parser.addFlag('suppress-warnings',
       defaultsTo: false,
       callback: (x) => extraction.suppressWarnings = x,
       help: 'Suppress printing of warnings.');
@@ -75,11 +75,11 @@ void main(List<String> args) {
       defaultsTo: '.',
       callback: (x) => targetDir = x,
       help: 'Specify the output directory.');
-  parser.addOption("generated-file-prefix",
+  parser.addOption('generated-file-prefix',
       defaultsTo: '',
       callback: (x) => generation.generatedFilePrefix = x,
       help: 'Specify a prefix to be used for the generated file names.');
-  parser.addFlag("use-deferred-loading",
+  parser.addFlag('use-deferred-loading',
       defaultsTo: true,
       callback: (x) => generation.useDeferredLoading = x,
       help: 'Generate message code that must be loaded with deferred loading. '
@@ -93,25 +93,25 @@ void main(List<String> args) {
       defaultsTo: 'debug',
       callback: (x) => generation.codegenMode = x,
       help: 'What mode to run the code generator in. Either release or debug.');
-  parser.addOption("sources-list-file",
+  parser.addOption('sources-list-file',
       callback: (value) => sourcesListFile = value,
       help: 'A file that lists the Dart files to read, one per line.'
           'The paths in the file can be absolute or relative to the '
           'location of this file.');
-  parser.addOption("translations-list-file",
+  parser.addOption('translations-list-file',
       callback: (value) => translationsListFile = value,
       help: 'A file that lists the translation files to process, one per line.'
           'The paths in the file can be absolute or relative to the '
           'location of this file.');
-  parser.addFlag("transformer",
+  parser.addFlag('transformer',
       defaultsTo: false,
       callback: (x) => transformer = x,
-      help: "Assume that the transformer is in use, so name and args "
+      help: 'Assume that the transformer is in use, so name and args '
           "don't need to be specified for messages.");
 
   parser.parse(args);
-  var dartFiles = args.where((x) => x.endsWith("dart")).toList();
-  var jsonFiles = args.where((x) => x.endsWith(".arb")).toList();
+  var dartFiles = args.where((x) => x.endsWith('dart')).toList();
+  var jsonFiles = args.where((x) => x.endsWith('.arb')).toList();
   dartFiles.addAll(linesFromFile(sourcesListFile));
   jsonFiles.addAll(linesFromFile(translationsListFile));
   if (dartFiles.isEmpty || jsonFiles.isEmpty) {
@@ -177,20 +177,20 @@ void main(List<String> args) {
   }
 }
 
-loadData(String filename, Map<String, List<Map>> messagesByLocale,
+void loadData(String filename, Map<String, List<Map>> messagesByLocale,
     MessageGeneration generation) {
   var file = File(filename);
   var src = file.readAsStringSync();
-  var data = jsonDecoder.decode(src);
-  var locale = data["@@locale"] ?? data["_locale"];
+  var data = jsonDecoder.decode(src) as Map<String, Object>;
+  var locale = data['@@locale'] ?? data['_locale'];
   if (locale == null) {
     // Get the locale from the end of the file name. This assumes that the file
     // name doesn't contain any underscores except to begin the language tag
     // and to separate language from country. Otherwise we can't tell if
     // my_file_fr.arb is locale "fr" or "file_fr".
     var name = path.basenameWithoutExtension(file.path);
-    locale = name.split("_").skip(1).join("_");
-    print("No @@locale or _locale field found in $name, "
+    locale = name.split('_').skip(1).join('_');
+    print('No @@locale or _locale field found in $name, '
         "assuming '$locale' based on the file name.");
   }
   messagesByLocale.putIfAbsent(locale, () => []).add(data);
@@ -224,7 +224,7 @@ void generateLocaleFile(String locale, List<Map> localeData, String targetDir,
 /// [data] to be a String. For metadata we expect [id] to start with "@"
 /// and [data] to be a Map or null. For metadata we return null.
 BasicTranslatedMessage recreateIntlObjects(String id, data) {
-  if (id.startsWith("@")) return null;
+  if (id.startsWith('@')) return null;
   if (data == null) return null;
   var parsed = pluralAndGenderParser.parse(data).value;
   if (parsed is LiteralString && parsed.string.isEmpty) {

--- a/bin/generate_from_arb.dart
+++ b/bin/generate_from_arb.dart
@@ -33,13 +33,13 @@ import 'package:path/path.dart' as path;
 /// name.
 Map<String, List<MainMessage>> messages;
 
-const jsonDecoder = const JsonCodec();
+const jsonDecoder = JsonCodec();
 
-main(List<String> args) {
+void main(List<String> args) {
   String targetDir;
-  var parser = new ArgParser();
-  var extraction = new MessageExtraction();
-  var generation = new MessageGeneration();
+  var parser = ArgParser();
+  var extraction = MessageExtraction();
+  var generation = MessageGeneration();
   String sourcesListFile;
   String translationsListFile;
   bool transformer;
@@ -140,10 +140,10 @@ main(List<String> args) {
   // for real projects we could provide a command-line flag to indicate which
   // sort of automated name we're using.
   extraction.suppressWarnings = true;
-  var allMessages = dartFiles
-      .map((each) => extraction.parseFile(new File(each), transformer));
+  var allMessages =
+      dartFiles.map((each) => extraction.parseFile(File(each), transformer));
 
-  messages = new Map();
+  messages = {};
   for (var eachMap in allMessages) {
     eachMap.forEach(
         (key, value) => messages.putIfAbsent(key, () => []).add(value));
@@ -161,17 +161,17 @@ main(List<String> args) {
     generateLocaleFile(locale, data, targetDir, generation);
   });
 
-  var mainImportFile = new File(path.join(
+  var mainImportFile = File(path.join(
       targetDir, '${generation.generatedFilePrefix}messages_all.dart'));
   mainImportFile.writeAsStringSync(
       generation.generateMainImportFile(flutter: useFlutterLocaleSplit));
 
-  var localesImportFile = new File(path.join(
+  var localesImportFile = File(path.join(
       targetDir, '${generation.generatedFilePrefix}messages_all_locales.dart'));
   localesImportFile.writeAsStringSync(generation.generateLocalesImportFile());
 
   if (useFlutterLocaleSplit) {
-    var flutterImportFile = new File(path.join(
+    var flutterImportFile = File(path.join(
         targetDir, '${generation.generatedFilePrefix}messages_flutter.dart'));
     flutterImportFile.writeAsStringSync(generation.generateFlutterImportFile());
   }
@@ -230,7 +230,7 @@ BasicTranslatedMessage recreateIntlObjects(String id, data) {
   if (parsed is LiteralString && parsed.string.isEmpty) {
     parsed = plainParser.parse(data).value;
   }
-  return new BasicTranslatedMessage(id, parsed);
+  return BasicTranslatedMessage(id, parsed);
 }
 
 /// A TranslatedMessage that just uses the name as the id and knows how to look
@@ -238,6 +238,7 @@ BasicTranslatedMessage recreateIntlObjects(String id, data) {
 class BasicTranslatedMessage extends TranslatedMessage {
   BasicTranslatedMessage(String name, translated) : super(name, translated);
 
+  @override
   List<MainMessage> get originalMessages => (super.originalMessages == null)
       ? _findOriginals()
       : super.originalMessages;
@@ -247,5 +248,5 @@ class BasicTranslatedMessage extends TranslatedMessage {
   List<MainMessage> _findOriginals() => originalMessages = messages[id];
 }
 
-final pluralAndGenderParser = new IcuParser().message;
-final plainParser = new IcuParser().nonIcuMessage;
+final pluralAndGenderParser = IcuParser().message;
+final plainParser = IcuParser().nonIcuMessage;

--- a/bin/make_examples_const.dart
+++ b/bin/make_examples_const.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:intl_translation/src/intl_message.dart';
 import 'package:intl_translation/src/message_rewriter.dart';
 
 void main(List<String> args) {
@@ -58,7 +59,8 @@ String rewriteMessages(String source, String sourceName) {
   return newSource.toString();
 }
 
-void rewrite(StringBuffer newSource, String source, int start, message) {
+void rewrite(
+    StringBuffer newSource, String source, int start, MainMessage message) {
   var originalSource =
       source.substring(message.sourcePosition, message.endPosition);
   var examples = nonConstExamples.firstMatch(originalSource);

--- a/bin/make_examples_const.dart
+++ b/bin/make_examples_const.dart
@@ -10,8 +10,8 @@ import 'package:args/args.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:intl_translation/src/message_rewriter.dart';
 
-main(List<String> args) {
-  var parser = new ArgParser();
+void main(List<String> args) {
+  var parser = ArgParser();
   var rest = parser.parse(args).rest;
   if (rest.isEmpty) {
     print('Accepts Dart file paths and rewrites the examples to be const '
@@ -21,17 +21,17 @@ main(List<String> args) {
     exit(0);
   }
 
-  var formatter = new DartFormatter();
+  var formatter = DartFormatter();
   for (var inputFile in rest) {
     var outputFile = inputFile;
-    var file = new File(inputFile);
+    var file = File(inputFile);
     var content = file.readAsStringSync();
     var newSource = rewriteMessages(content, '$file');
     if (content == newSource) {
       print('No changes to $outputFile');
     } else {
       print('Writing new source to $outputFile');
-      var out = new File(outputFile);
+      var out = File(outputFile);
       out.writeAsStringSync(formatter.format(newSource));
     }
   }
@@ -46,7 +46,7 @@ String rewriteMessages(String source, String sourceName) {
   var messages = findMessages(source, sourceName);
   messages.sort((a, b) => a.sourcePosition.compareTo(b.sourcePosition));
   var start = 0;
-  var newSource = new StringBuffer();
+  var newSource = StringBuffer();
   for (var message in messages) {
     if (message.examples != null) {
       newSource.write(source.substring(start, message.sourcePosition));
@@ -71,4 +71,4 @@ void rewrite(StringBuffer newSource, String source, int start, message) {
   }
 }
 
-final RegExp nonConstExamples = new RegExp('([\\n,]\\s+examples\: ){');
+final RegExp nonConstExamples = RegExp('([\\n,]\\s+examples: ){');

--- a/bin/make_examples_const.dart
+++ b/bin/make_examples_const.dart
@@ -68,7 +68,7 @@ void rewrite(
     newSource.write(originalSource);
   } else {
     var modifiedSource = originalSource.replaceFirst(
-        examples.group(1), examples.group(1) + 'const');
+        examples.group(1), '${examples.group(1)}const');
     newSource.write(modifiedSource);
   }
 }

--- a/bin/rewrite_intl_messages.dart
+++ b/bin/rewrite_intl_messages.dart
@@ -10,7 +10,6 @@
 /// It takes as input a single source Dart file and rewrites any
 /// Intl.message or related calls to automatically include the name and args
 /// parameters and writes the result to stdout.
-
 import 'dart:io';
 
 import 'package:args/args.dart';

--- a/bin/rewrite_intl_messages.dart
+++ b/bin/rewrite_intl_messages.dart
@@ -22,8 +22,8 @@ String outputFileOption = 'transformed_output.dart';
 bool useStringSubstitution = true;
 bool replace = false;
 
-main(List<String> args) {
-  var parser = new ArgParser();
+void main(List<String> args) {
+  var parser = ArgParser();
   parser.addOption('output',
       defaultsTo: 'transformed_output.dart',
       callback: (x) => outputFileOption = x,
@@ -54,10 +54,10 @@ main(List<String> args) {
     exit(0);
   }
 
-  var formatter = new DartFormatter();
+  var formatter = DartFormatter();
   for (var inputFile in rest) {
     var outputFile = replace ? inputFile : outputFileOption;
-    var file = new File(inputFile);
+    var file = File(inputFile);
     var content = file.readAsStringSync();
     var newSource = rewriteMessages(content, '$file',
         useStringSubstitution: useStringSubstitution);
@@ -65,7 +65,7 @@ main(List<String> args) {
       print('No changes to $outputFile');
     } else {
       print('Writing new source to $outputFile');
-      var out = new File(outputFile);
+      var out = File(outputFile);
       out.writeAsStringSync(formatter.format(newSource));
     }
   }

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: implementation_imports
+
 /// This is for use in extracting messages from a Dart program
 /// using the Intl.message() mechanism and writing them to a file for
 /// translation. This provides only the stub of a mechanism, because it
@@ -483,8 +485,8 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   /// and the parameters to the Intl.plural or Intl.gender call.
   MainMessage messageFromDirectPluralOrGenderCall(MethodInvocation node) {
     MainMessage extractFromPluralOrGender(MainMessage message, _) {
-      var visitor = PluralAndGenderVisitor(
-          message.messagePieces, message, extraction);
+      var visitor =
+          PluralAndGenderVisitor(message.messagePieces, message, extraction);
       node.accept(visitor);
       return message;
     }

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -389,9 +389,10 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   /// [messageFromIntlMessageCall] and [messageFromDirectPluralOrGenderCall].
   MainMessage _messageFromNode(
       MethodInvocation node,
-      MainMessage Function(MainMessage message, List<AstNode> arguments) extract,
-      void Function(
-          MainMessage message, String fieldName, Object fieldValue) setAttribute) {
+      MainMessage Function(MainMessage message, List<AstNode> arguments)
+          extract,
+      void Function(MainMessage message, String fieldName, Object fieldValue)
+          setAttribute) {
     var message = MainMessage();
     message.sourcePosition = node.offset;
     message.endPosition = node.end;
@@ -580,7 +581,7 @@ class InterpolationVisitor extends SimpleAstVisitor {
 /// A visitor to extract information from Intl.plural/gender sends. Note that
 /// this is a SimpleAstVisitor, so it doesn't automatically recurse. So this
 /// needs to be called where we expect a plural or gender immediately below.
-class PluralAndGenderVisitor extends SimpleAstVisitor {
+class PluralAndGenderVisitor extends SimpleAstVisitor<void> {
   /// The message extraction in which we are running.
   final MessageExtraction extraction;
 
@@ -598,7 +599,7 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
   PluralAndGenderVisitor(this.pieces, this.parent, this.extraction) : super();
 
   @override
-  visitInterpolationExpression(InterpolationExpression node) {
+  void visitInterpolationExpression(InterpolationExpression node) {
     // TODO(alanknight): Provide better errors for malformed expressions.
     if (!looksLikePluralOrGender(node.expression)) return;
     var reason = checkValidity(node.expression);
@@ -610,7 +611,7 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
   }
 
   @override
-  visitMethodInvocation(MethodInvocation node) {
+  void visitMethodInvocation(MethodInvocation node) {
     pieces.add(messageFromMethodInvocation(node));
     super.visitMethodInvocation(node);
   }

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -659,6 +659,7 @@ class PluralAndGenderVisitor extends SimpleAstVisitor<void> {
 
     var arguments = message.argumentsOfInterestFor(node);
     arguments.forEach((key, value) {
+      // `value` is often - or always? - an Expression.
       try {
         var interpolation = InterpolationVisitor(message, extraction);
         value.accept(interpolation);

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -230,6 +230,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
 
   /// Record the parameters of the function or method declaration we last
   /// encountered before seeing the Intl.message call.
+  @override
   void visitMethodDeclaration(MethodDeclaration node) {
     name = node.name.name;
     parameters = node.parameters?.parameters ?? _emptyParameterList;
@@ -242,6 +243,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
 
   /// Record the parameters of the function or method declaration we last
   /// encountered before seeing the Intl.message call.
+  @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
     name = node.name.name;
     parameters =
@@ -255,6 +257,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
 
   /// Record the name of field declaration we last
   /// encountered before seeing the Intl.message call.
+  @override
   void visitFieldDeclaration(FieldDeclaration node) {
     // We don't support names in list declarations,
     // e.g. String first, second = Intl.message(...);
@@ -273,6 +276,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
 
   /// Record the name of the top level variable declaration we last
   /// encountered before seeing the Intl.message call.
+  @override
   void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
     // We don't support names in list declarations,
     // e.g. String first, second = Intl.message(...);
@@ -293,6 +297,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   /// If we've found one, stop recursing. This is important because we can have
   /// Intl.message(...Intl.plural...) and we don't want to treat the inner
   /// plural as if it was an outermost message.
+  @override
   void visitMethodInvocation(MethodInvocation node) {
     if (!addIntlMessage(node)) {
       super.visitMethodInvocation(node);
@@ -513,26 +518,31 @@ class InterpolationVisitor extends SimpleAstVisitor {
   List pieces = [];
   String get extractedMessage => pieces.join();
 
+  @override
   void visitAdjacentStrings(AdjacentStrings node) {
     node.visitChildren(this);
     super.visitAdjacentStrings(node);
   }
 
+  @override
   void visitStringInterpolation(StringInterpolation node) {
     node.visitChildren(this);
     super.visitStringInterpolation(node);
   }
 
+  @override
   void visitSimpleStringLiteral(SimpleStringLiteral node) {
     pieces.add(node.value);
     super.visitSimpleStringLiteral(node);
   }
 
+  @override
   void visitInterpolationString(InterpolationString node) {
     pieces.add(node.value);
     super.visitInterpolationString(node);
   }
 
+  @override
   void visitInterpolationExpression(InterpolationExpression node) {
     if (node.expression is SimpleIdentifier) {
       handleSimpleInterpolation(node);
@@ -585,6 +595,7 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
 
   PluralAndGenderVisitor(this.pieces, this.parent, this.extraction) : super();
 
+  @override
   visitInterpolationExpression(InterpolationExpression node) {
     // TODO(alanknight): Provide better errors for malformed expressions.
     if (!looksLikePluralOrGender(node.expression)) return;
@@ -596,6 +607,7 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
     super.visitInterpolationExpression(node);
   }
 
+  @override
   visitMethodInvocation(MethodInvocation node) {
     pieces.add(messageFromMethodInvocation(node));
     super.visitMethodInvocation(node);

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -164,7 +164,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   final MessageExtraction extraction;
 
   /// Accumulates the messages we have found, keyed by name.
-  final Map<String, MainMessage> messages = Map<String, MainMessage>();
+  final Map<String, MainMessage> messages = <String, MainMessage>{};
 
   /// Should we generate the name and arguments from the function definition,
   /// meaning we're running in the transformer.
@@ -389,9 +389,9 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   /// [messageFromIntlMessageCall] and [messageFromDirectPluralOrGenderCall].
   MainMessage _messageFromNode(
       MethodInvocation node,
-      MainMessage extract(MainMessage message, List<AstNode> arguments),
-      void setAttribute(
-          MainMessage message, String fieldName, Object fieldValue)) {
+      MainMessage Function(MainMessage message, List<AstNode> arguments) extract,
+      void Function(
+          MainMessage message, String fieldName, Object fieldValue) setAttribute) {
     var message = MainMessage();
     message.sourcePosition = node.offset;
     message.endPosition = node.end;
@@ -622,7 +622,7 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
     if (!['plural', 'gender', 'select'].contains(node.methodName.name)) {
       return false;
     }
-    if (!(node.target is SimpleIdentifier)) return false;
+    if (node.target is! SimpleIdentifier) return false;
     SimpleIdentifier target = node.target;
     return target.token.toString() == 'Intl';
   }
@@ -703,5 +703,5 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
 // NOTE: THIS LOGIC IS DUPLICATED IN intl AND THE TWO MUST MATCH.
 String computeMessageName(String name, String text, String meaning) {
   if (name != null && name != '') return name;
-  return meaning == null ? text : '${text}_${meaning}';
+  return meaning == null ? text : '${text}_$meaning';
 }

--- a/lib/extract_messages.dart
+++ b/lib/extract_messages.dart
@@ -110,7 +110,7 @@ class MessageExtraction {
     } else {
       return {};
     }
-    var visitor = new MessageFindingVisitor(this);
+    var visitor = MessageFindingVisitor(this);
     visitor.generateNameAndArgs = transformer;
     root.accept(visitor);
     return visitor.messages;
@@ -121,7 +121,7 @@ class MessageExtraction {
         content: contents, featureSet: _featureSet, throwIfDiagnostics: false);
 
     if (result.errors.isNotEmpty) {
-      print("Error in parsing $origin, no messages extracted.");
+      print('Error in parsing $origin, no messages extracted.');
       throw ArgumentError('Parsing errors in $origin');
     }
 
@@ -139,13 +139,13 @@ class MessageExtraction {
   String origin;
 
   String _reportErrorLocation(AstNode node) {
-    var result = new StringBuffer();
-    if (origin != null) result.write("    from $origin");
+    var result = StringBuffer();
+    if (origin != null) result.write('    from $origin');
     var info = root.lineInfo;
     if (info != null) {
       var line = info.getLocation(node.offset);
       result
-          .write("    line: ${line.lineNumber}, column: ${line.columnNumber}");
+          .write('    line: ${line.lineNumber}, column: ${line.columnNumber}');
     }
     return result.toString();
   }
@@ -162,7 +162,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   final MessageExtraction extraction;
 
   /// Accumulates the messages we have found, keyed by name.
-  final Map<String, MainMessage> messages = new Map<String, MainMessage>();
+  final Map<String, MainMessage> messages = Map<String, MainMessage>();
 
   /// Should we generate the name and arguments from the function definition,
   /// meaning we're running in the transformer.
@@ -184,7 +184,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
 
   /// Return true if [node] matches the pattern we expect for Intl.message()
   bool looksLikeIntlMessage(MethodInvocation node) {
-    const validNames = const ["message", "plural", "gender", "select"];
+    const validNames = ['message', 'plural', 'gender', 'select'];
     if (!validNames.contains(node.methodName.name)) return false;
     final target = node.target;
     if (target is SimpleIdentifier) {
@@ -198,13 +198,13 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   Message _expectedInstance(String type) {
     switch (type) {
       case 'message':
-        return new MainMessage();
+        return MainMessage();
       case 'plural':
-        return new Plural();
+        return Plural();
       case 'gender':
-        return new Gender();
+        return Gender();
       case 'select':
-        return new Select();
+        return Select();
       default:
         return null;
     }
@@ -214,12 +214,12 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   /// reason is found, so it's presumed valid.
   String checkValidity(MethodInvocation node) {
     if (parameters == null) {
-      return "Calls to Intl must be inside a method, field declaration or "
-          "top level declaration.";
+      return 'Calls to Intl must be inside a method, field declaration or '
+          'top level declaration.';
     }
     // The containing function cannot have named parameters.
     if (parameters.any((each) => each.isNamed)) {
-      return "Named parameters on message functions are not supported.";
+      return 'Named parameters on message functions are not supported.';
     }
     var arguments = node.argumentList.arguments;
     var instance = _expectedInstance(node.methodName.name);
@@ -309,10 +309,10 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
 
     if (reason != null) {
       if (!extraction.suppressWarnings) {
-        var err = new StringBuffer()
-          ..write("Skipping invalid Intl.message invocation\n    <$node>\n")
+        var err = StringBuffer()
+          ..write('Skipping invalid Intl.message invocation\n    <$node>\n')
           ..writeAll(
-              ["    reason: $reason\n", extraction._reportErrorLocation(node)]);
+              ['    reason: $reason\n', extraction._reportErrorLocation(node)]);
         var errString = err.toString();
         extraction.warnings.add(errString);
         extraction.onMessage(errString);
@@ -327,13 +327,13 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   String _extractMessage(MethodInvocation node) {
     MainMessage message;
     try {
-      if (node.methodName.name == "message") {
+      if (node.methodName.name == 'message') {
         message = messageFromIntlMessageCall(node);
       } else {
         message = messageFromDirectPluralOrGenderCall(node);
       }
     } catch (e, s) {
-      return "Unexpected exception: $e, $s";
+      return 'Unexpected exception: $e, $s';
     }
     return message == null ? null : _validateMessage(message);
   }
@@ -364,7 +364,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
       var messageCode =
           message.toOriginalCode(includeDesc: false, includeExamples: false);
       if (existingCode != messageCode) {
-        return "WARNING: Duplicate message name:\n"
+        return 'WARNING: Duplicate message name:\n'
             "'${message.name}' occurs more than once in ${extraction.origin}";
       }
     } else {
@@ -385,7 +385,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
       MainMessage extract(MainMessage message, List<AstNode> arguments),
       void setAttribute(
           MainMessage message, String fieldName, Object fieldValue)) {
-    var message = new MainMessage();
+    var message = MainMessage();
     message.sourcePosition = node.offset;
     message.endPosition = node.end;
     message.arguments = parameters.map((x) => x.identifier.name).toList();
@@ -400,7 +400,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
     for (var namedArgument in arguments.whereType<NamedExpression>()) {
       var name = namedArgument.name.label.name;
       var exp = namedArgument.expression;
-      var evaluator = new ConstantEvaluator();
+      var evaluator = ConstantEvaluator();
       var basicValue = exp.accept(evaluator);
       var value = basicValue == ConstantEvaluator.NOT_A_CONSTANT
           ? exp.toString()
@@ -429,14 +429,14 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   /// Find the message pieces from a Dart interpolated string.
   List _extractFromIntlCallWithInterpolation(
       MainMessage message, List<AstNode> arguments) {
-    var interpolation = new InterpolationVisitor(message, extraction);
+    var interpolation = InterpolationVisitor(message, extraction);
     arguments.first.accept(interpolation);
     if (interpolation.pieces.any((x) => x is Plural || x is Gender) &&
         !extraction.allowEmbeddedPluralsAndGenders) {
       if (interpolation.pieces.any((x) => x is String && x.isNotEmpty)) {
-        throw new IntlMessageExtractionException(
-            "Plural and gender expressions must be at the top level, "
-            "they cannot be embedded in larger string literals.\n");
+        throw IntlMessageExtractionException(
+            'Plural and gender expressions must be at the top level, '
+            'they cannot be embedded in larger string literals.\n');
       }
     }
     return interpolation.pieces;
@@ -456,8 +456,8 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
         message.addPieces(extracted);
       } on IntlMessageExtractionException catch (e) {
         message = null;
-        var err = new StringBuffer()
-          ..writeAll(["Error ", e, "\nProcessing <", node, ">\n"])
+        var err = StringBuffer()
+          ..writeAll(['Error ', e, '\nProcessing <', node, '>\n'])
           ..write(extraction._reportErrorLocation(node));
         var errString = err.toString();
         extraction.onMessage(errString);
@@ -478,7 +478,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
   /// and the parameters to the Intl.plural or Intl.gender call.
   MainMessage messageFromDirectPluralOrGenderCall(MethodInvocation node) {
     MainMessage extractFromPluralOrGender(MainMessage message, _) {
-      var visitor = new PluralAndGenderVisitor(
+      var visitor = PluralAndGenderVisitor(
           message.messagePieces, message, extraction);
       node.accept(visitor);
       return message;
@@ -543,21 +543,21 @@ class InterpolationVisitor extends SimpleAstVisitor {
   }
 
   void lookForPluralOrGender(InterpolationExpression node) {
-    var visitor = new PluralAndGenderVisitor(pieces, message, extraction);
+    var visitor = PluralAndGenderVisitor(pieces, message, extraction);
     node.accept(visitor);
     if (!visitor.foundPluralOrGender) {
-      throw new IntlMessageExtractionException(
-          "Only simple identifiers and Intl.plural/gender/select expressions "
-          "are allowed in message "
-          "interpolation expressions.\nError at $node");
+      throw IntlMessageExtractionException(
+          'Only simple identifiers and Intl.plural/gender/select expressions '
+          'are allowed in message '
+          'interpolation expressions.\nError at $node');
     }
   }
 
   void handleSimpleInterpolation(InterpolationExpression node) {
     var index = arguments.indexOf(node.expression.toString());
     if (index == -1) {
-      throw new IntlMessageExtractionException(
-          "Cannot find argument ${node.expression}");
+      throw IntlMessageExtractionException(
+          'Cannot find argument ${node.expression}');
     }
     pieces.add(index);
   }
@@ -605,12 +605,12 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
   bool looksLikePluralOrGender(Expression expression) {
     if (expression is! MethodInvocation) return false;
     final node = expression as MethodInvocation;
-    if (!["plural", "gender", "select"].contains(node.methodName.name)) {
+    if (!['plural', 'gender', 'select'].contains(node.methodName.name)) {
       return false;
     }
     if (!(node.target is SimpleIdentifier)) return false;
     SimpleIdentifier target = node.target;
-    return target.token.toString() == "Intl";
+    return target.token.toString() == 'Intl';
   }
 
   /// Returns a String describing why the node is invalid, or null if no
@@ -626,26 +626,26 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
   Message messageFromMethodInvocation(MethodInvocation node) {
     SubMessage message;
     switch (node.methodName.name) {
-      case "gender":
-        message = new Gender();
+      case 'gender':
+        message = Gender();
         break;
-      case "plural":
-        message = new Plural();
+      case 'plural':
+        message = Plural();
         break;
-      case "select":
-        message = new Select();
+      case 'select':
+        message = Select();
         break;
       default:
-        throw new IntlMessageExtractionException(
-            "Invalid plural/gender/select message ${node.methodName.name} "
-            "in $node");
+        throw IntlMessageExtractionException(
+            'Invalid plural/gender/select message ${node.methodName.name} '
+            'in $node');
     }
     message.parent = parent;
 
     var arguments = message.argumentsOfInterestFor(node);
     arguments.forEach((key, value) {
       try {
-        var interpolation = new InterpolationVisitor(message, extraction);
+        var interpolation = InterpolationVisitor(message, extraction);
         value.accept(interpolation);
         // Might be null due to previous errors.
         // Continue collecting errors, but don't build message.
@@ -654,8 +654,8 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
         }
       } on IntlMessageExtractionException catch (e) {
         message = null;
-        var err = new StringBuffer()
-          ..writeAll(["Error ", e, "\nProcessing <", node, ">"])
+        var err = StringBuffer()
+          ..writeAll(['Error ', e, '\nProcessing <', node, '>'])
           ..write(extraction._reportErrorLocation(node));
         var errString = err.toString();
         extraction.onMessage(errString);
@@ -670,10 +670,10 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
     } else if (mainArg is SimpleIdentifier) {
       message.mainArgument = mainArg.name;
     } else {
-      var err = new StringBuffer()
-        ..write("Error (Invalid argument to plural/gender/select, "
-            "must be simple variable reference) "
-            "\nProcessing <$node>")
+      var err = StringBuffer()
+        ..write('Error (Invalid argument to plural/gender/select, '
+            'must be simple variable reference) '
+            '\nProcessing <$node>')
         ..write(extraction._reportErrorLocation(node));
       var errString = err.toString();
       extraction.onMessage(errString);
@@ -688,6 +688,6 @@ class PluralAndGenderVisitor extends SimpleAstVisitor {
 /// a name based on that and the meaning, if present.
 // NOTE: THIS LOGIC IS DUPLICATED IN intl AND THE TWO MUST MATCH.
 String computeMessageName(String name, String text, String meaning) {
-  if (name != null && name != "") return name;
-  return meaning == null ? text : "${text}_${meaning}";
+  if (name != null && name != '') return name;
+  return meaning == null ? text : '${text}_${meaning}';
 }

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -348,11 +348,13 @@ MessageLookupByLibrary$orNull _findGeneratedMessagesFor(String locale) {
 abstract class DataMapMessageGeneration extends MessageGeneration {
   /// We import the main file so as to get the shared code to evaluate
   /// the JSON data.
+  @override
   String get extraImports => '''
 import 'dart:convert';
 import '${generatedFilePrefix}messages_all.dart' show evaluateJsonTemplate;
 ''';
 
+  @override
   String prologue(locale) =>
       super.prologue(locale) +
       '''
@@ -361,15 +363,18 @@ import '${generatedFilePrefix}messages_all.dart' show evaluateJsonTemplate;
   }
 ''';
 
+  @override
   void writeTranslations(
       Iterable<TranslatedMessage> usableTranslations, String locale);
 
+  @override
   get mainPrologue =>
       super.mainPrologue +
       """
 import 'package:$intlImportPath/intl.dart';
 """;
 
+  @override
   get closing =>
       super.closing +
       '''
@@ -437,6 +442,7 @@ String$orNull evaluateJsonTemplate(dynamic input, List<dynamic> args) {
 
  ''';
 
+  @override
   String generateFlutterImportFile() {
     clearOutput();
     output.write(flutterPrologue);
@@ -708,10 +714,13 @@ abstract class TranslatedMessage {
 
   Message get message => translated;
 
+  @override
   toString() => id.toString();
 
+  @override
   operator ==(x) => x is TranslatedMessage && x.id == id;
 
+  @override
   get hashCode => id.hashCode;
 }
 

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -166,8 +166,7 @@ class MessageGeneration {
 
   /// [generateIndividualMessageFile] for the beginning of the file,
   /// parameterized by [locale].
-  String prologue(String locale) =>
-      """
+  String prologue(String locale) => '''
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that provides messages for a $locale locale. All the
 // messages from the main program should be duplicated here with the same
@@ -190,8 +189,7 @@ typedef String$orNull MessageIfAbsent(
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => '$locale';
 
-""" +
-      (releaseMode ? overrideLookup() : '');
+${releaseMode ? overrideLookup() : ''}''';
 
   String overrideLookup() => """
   String$orNull lookupMessage(
@@ -351,13 +349,12 @@ abstract class DataMapMessageGeneration extends MessageGeneration {
   @override
   String get extraImports => '''
 import 'dart:convert';
+
 import '${generatedFilePrefix}messages_all.dart' show evaluateJsonTemplate;
 ''';
 
   @override
-  String prologue(String locale) =>
-      super.prologue(locale) +
-      '''
+  String prologue(String locale) => '''${super.prologue(locale)}
   String$orNull evaluateMessage(translation, List<dynamic> args) {
     return evaluateJsonTemplate(translation, args);
   }
@@ -368,16 +365,13 @@ import '${generatedFilePrefix}messages_all.dart' show evaluateJsonTemplate;
       Iterable<TranslatedMessage> usableTranslations, String locale);
 
   @override
-  String get mainPrologue =>
-      super.mainPrologue +
-      """
+  String get mainPrologue => """${super.mainPrologue}
+
 import 'package:$intlImportPath/intl.dart';
 """;
 
   @override
-  String get closing =>
-      super.closing +
-      '''
+  String get closing => '''${super.closing}
 /// Turn the JSON template into a string.
 ///
 /// We expect one of the following forms for the template.
@@ -697,12 +691,7 @@ abstract class TranslatedMessage {
 
   /// The original messages that we are a translation of. There can
   ///  be more than one original message for the same translation.
-  List<MainMessage> _originalMessages;
-
-  List<MainMessage> get originalMessages => _originalMessages;
-  set originalMessages(List<MainMessage> x) {
-    _originalMessages = x;
-  }
+  List<MainMessage> originalMessages;
 
   /// For backward compatibility, we still have the originalMessage API.
   MainMessage get originalMessage => originalMessages.first;
@@ -728,7 +717,7 @@ abstract class TranslatedMessage {
 /// We can't use a hyphen in a Dart library name, so convert the locale
 /// separator to an underscore.
 String libraryName(String x) =>
-    'messages_' + x.replaceAll('-', '_').toLowerCase();
+    'messages_${x.replaceAll('-', '_').toLowerCase()}';
 
 bool _hasArguments(MainMessage message) => message.arguments.isNotEmpty;
 

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -40,7 +40,7 @@ class MessageGeneration {
   /// By default, that is in the current directory, but if [generatedImportPath]
   /// has been set, then use that as a prefix.
   String importForGeneratedFile(String file) =>
-      generatedImportPath.isEmpty ? file : "$generatedImportPath/$file";
+      generatedImportPath.isEmpty ? file : '$generatedImportPath/$file';
 
   /// A list of all the locales for which we have translations. Code that does
   /// the reading of translations should add to this.
@@ -71,12 +71,12 @@ class MessageGeneration {
   bool get releaseMode => codegenMode == 'release';
 
   /// Holds the generated translations.
-  StringBuffer output = new StringBuffer();
+  StringBuffer output = StringBuffer();
 
   String get orNull => nullSafety ? '?' : '';
 
   void clearOutput() {
-    output = new StringBuffer();
+    output = StringBuffer();
   }
 
   /// Generate a file <[generated_file_prefix]>_messages_<[locale]>.dart
@@ -97,7 +97,7 @@ class MessageGeneration {
   String contentForLocale(
       String basicLocale, Iterable<TranslatedMessage> translations) {
     clearOutput();
-    var locale = new MainMessage()
+    var locale = MainMessage()
         .escapeAndValidateString(Intl.canonicalizedLocale(basicLocale));
     output.write(prologue(locale));
     // Exclude messages with no translation and translations with no matching
@@ -129,10 +129,10 @@ class MessageGeneration {
           translation.originalMessages.where(_hasArguments).toSet().toList();
       for (var original in messagesThatNeedMethods) {
         output
-          ..write("  ")
+          ..write('  ')
           ..write(
               original.toCodeForLocale(locale, _methodNameFor(original.name)))
-          ..write("\n\n");
+          ..write('\n\n');
       }
     }
     output.write(messagesDeclaration);
@@ -148,8 +148,8 @@ class MessageGeneration {
             '    "${original.escapeAndValidateString(original.name)}" '
             ': ${_mapReference(original, locale)}');
     output
-      ..write(entries.join(",\n"))
-      ..write("\n  };\n}\n");
+      ..write(entries.join(',\n'))
+      ..write('\n  };\n}\n');
   }
 
   /// Any additional imports the individual message files need.
@@ -159,10 +159,10 @@ class MessageGeneration {
       // Includes some gyrations to prevent parts of the deferred libraries from
       // being inlined into the main one, defeating the space savings. Issue
       // 24356
-      """
+      '''
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function> {
-""";
+''';
 
   /// [generateIndividualMessageFile] for the beginning of the file,
   /// parameterized by [locale].
@@ -191,7 +191,7 @@ class MessageLookup extends MessageLookupByLibrary {
   String get localeName => '$locale';
 
 """ +
-      (releaseMode ? overrideLookup() : "");
+      (releaseMode ? overrideLookup() : '');
 
   String overrideLookup() => """
   String$orNull lookupMessage(
@@ -225,12 +225,12 @@ class MessageLookup extends MessageLookupByLibrary {
       var baseFile = '${generatedFilePrefix}messages_$locale.dart';
       var file = importForGeneratedFile(baseFile);
       output.write("import '$file' ");
-      if (useDeferredLoading) output.write("deferred ");
-      output.write("as ${libraryName(locale)};\n");
+      if (useDeferredLoading) output.write('deferred ');
+      output.write('as ${libraryName(locale)};\n');
     }
-    output.write("\n");
-    output.write("typedef Future<dynamic> LibraryLoader();\n");
-    output.write("Map<String, LibraryLoader> _deferredLibraries = {\n");
+    output.write('\n');
+    output.write('typedef Future<dynamic> LibraryLoader();\n');
+    output.write('Map<String, LibraryLoader> _deferredLibraries = {\n');
     for (var rawLocale in allLocales) {
       var locale = Intl.canonicalizedLocale(rawLocale);
       var loadOperation = (useDeferredLoading)
@@ -238,10 +238,10 @@ class MessageLookup extends MessageLookupByLibrary {
           : "  '$locale': () => new Future.value(null),\n";
       output.write(loadOperation);
     }
-    output.write("};\n");
+    output.write('};\n');
     output.write(
-        "\nMessageLookupByLibrary$orNull _findExact(String localeName) {\n"
-        "  switch (localeName) {\n");
+        '\nMessageLookupByLibrary$orNull _findExact(String localeName) {\n'
+        '  switch (localeName) {\n');
     for (var rawLocale in allLocales) {
       var locale = Intl.canonicalizedLocale(rawLocale);
       output.write(
@@ -273,7 +273,7 @@ import 'package:$intlImportPath/src/intl_helpers.dart';
 
   /// Constant string used in [generateLocalesImportFile] as the end of the
   /// file.
-  get localesClosing => """
+  get localesClosing => '''
     default:\n      return null;
   }
 }
@@ -308,7 +308,7 @@ MessageLookupByLibrary$orNull _findGeneratedMessagesFor(String locale) {
   if (actualLocale == null) return null;
   return _findExact(actualLocale);
 }
-""";
+''';
 
   String generateFlutterImportFile() => throw UnimplementedError();
 
@@ -330,12 +330,12 @@ MessageLookupByLibrary$orNull _findGeneratedMessagesFor(String locale) {
 
   /// Constant string used in [generateMainImportFile] for the beginning of the
   /// file.
-  get mainPrologue => """
+  get mainPrologue => '''
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
 
-""";
+''';
 
   /// Constant string used in [generateMainImportFile] as the end of the file.
   get closing => '';
@@ -539,20 +539,20 @@ class JsonMessageGeneration extends DataMapMessageGeneration {
   @override
   void writeTranslations(
       Iterable<TranslatedMessage> usableTranslations, String locale) {
-    output.write("""
+    output.write('''
   Map<String, dynamic>$orNull _messages;
   Map<String, dynamic> get messages => _messages ??=
       const JsonDecoder().convert(messageText) as Map<String, dynamic>;
-""");
+''');
 
-    output.write("  static final messageText = ");
+    output.write('  static final messageText = ');
     var entries = usableTranslations
         .expand((translation) => translation.originalMessages);
     var map = {};
     for (var original in entries) {
       map[original.name] = original.toJsonForLocale(locale);
     }
-    var jsonEncoded = new JsonEncoder().convert(map);
+    var jsonEncoded = JsonEncoder().convert(map);
     output.write(_embedInLiteral(jsonEncoded));
   }
 }
@@ -568,9 +568,9 @@ import 'dart:collection';
   @override
   void writeTranslations(
       Iterable<TranslatedMessage> usableTranslations, String locale) {
-    output.write("""
+    output.write('''
   Map<String, dynamic> get messages => _constMessages;
-""");
+''');
 
     var entries = usableTranslations
         .expand((translation) => translation.originalMessages);
@@ -579,11 +579,11 @@ import 'dart:collection';
       map[original.name] = original.toJsonForLocale(locale);
     }
 
-    output.write("  static const _constMessages = ");
+    output.write('  static const _constMessages = ');
     _writeValue(map);
 
-    output.write(";\n\n");
-    output.write("}");
+    output.write(';\n\n');
+    output.write('}');
   }
 
   void _writeValue(Object value) {
@@ -749,5 +749,5 @@ Map<String, String> _internalMethodNames = {};
 /// Generate a Dart method name of the form "m<number>".
 String _methodNameFor(String name) {
   return _internalMethodNames.putIfAbsent(
-      name, () => "m${_methodNameCounter++}");
+      name, () => 'm${_methodNameCounter++}');
 }

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -366,7 +366,6 @@ import '${generatedFilePrefix}messages_all.dart' show evaluateJsonTemplate;
 
   @override
   String get mainPrologue => """${super.mainPrologue}
-
 import 'package:$intlImportPath/intl.dart';
 """;
 

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -385,10 +385,10 @@ import 'package:$intlImportPath/intl.dart';
 /// * String s -> s
 /// * int n -> '\${args[n]}'
 /// * List list, one of
-///   * \['Intl.plural', int howMany, (templates for zero, one, ...)\]
-///   * \['Intl.gender', String gender, (templates for female, male, other)\]
-///   * \['Intl.select', String choice, { 'case' : template, ...} \]
-///   * \['text alternating with ', 0 , ' indexes in the argument list'\]
+///   * ['Intl.plural', int howMany, (templates for zero, one, ...)]
+///   * ['Intl.gender', String gender, (templates for female, male, other)]
+///   * ['Intl.select', String choice, { 'case' : template, ...} ]
+///   * ['text alternating with ', 0 , ' indexes in the argument list']
 String$orNull evaluateJsonTemplate(dynamic input, List<dynamic> args) {
   if (input == null) return null;
   if (input is String) return input;

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -23,18 +23,18 @@ class MessageGeneration {
   /// If the import path following package: is something else, modify the
   /// [intlImportPath] variable to change the import directives in the generated
   /// code.
-  var intlImportPath = 'intl';
+  String intlImportPath = 'intl';
 
   /// If the import path for flutter is not package:flutter, modify the
   /// [flutterImportPath] variable to change the import directives in the
   /// generated code. This is useful to mock out Flutter during tests since
   /// package:flutter cannot be imported from Dart VM.
-  var flutterImportPath = 'package:flutter';
+  String flutterImportPath = 'package:flutter';
 
   /// If the path to the generated files is something other than the current
   /// directory, update the [generatedImportPath] variable to change the import
   /// directives in the generated code.
-  var generatedImportPath = '';
+  String generatedImportPath = '';
 
   /// Given a base file, return the file prefixed with the path to import it.
   /// By default, that is in the current directory, but if [generatedImportPath]
@@ -355,7 +355,7 @@ import '${generatedFilePrefix}messages_all.dart' show evaluateJsonTemplate;
 ''';
 
   @override
-  String prologue(locale) =>
+  String prologue(String locale) =>
       super.prologue(locale) +
       '''
   String$orNull evaluateMessage(translation, List<dynamic> args) {
@@ -718,7 +718,8 @@ abstract class TranslatedMessage {
   String toString() => id.toString();
 
   @override
-  bool operator ==(other) => other is TranslatedMessage && other.id == id;
+  bool operator ==(Object other) =>
+      other is TranslatedMessage && other.id == id;
 
   @override
   int get hashCode => id.hashCode;

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -44,7 +44,7 @@ class MessageGeneration {
 
   /// A list of all the locales for which we have translations. Code that does
   /// the reading of translations should add to this.
-  Set<String> allLocales = Set();
+  Set<String> allLocales = {};
 
   /// If we have more than one set of messages to generate in a particular
   /// directory we may want to prefix some to distinguish them.
@@ -718,7 +718,7 @@ abstract class TranslatedMessage {
   toString() => id.toString();
 
   @override
-  operator ==(x) => x is TranslatedMessage && x.id == id;
+  bool operator ==(other) => other is TranslatedMessage && other.id == id;
 
   @override
   get hashCode => id.hashCode;

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -253,7 +253,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   /// Constant string used in [generateLocalesImportFile] for the beginning of
   /// the file.
-  get localesPrologue => """
+  String get localesPrologue => """
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
@@ -273,7 +273,7 @@ import 'package:$intlImportPath/src/intl_helpers.dart';
 
   /// Constant string used in [generateLocalesImportFile] as the end of the
   /// file.
-  get localesClosing => '''
+  String get localesClosing => '''
     default:\n      return null;
   }
 }
@@ -330,7 +330,7 @@ MessageLookupByLibrary$orNull _findGeneratedMessagesFor(String locale) {
 
   /// Constant string used in [generateMainImportFile] for the beginning of the
   /// file.
-  get mainPrologue => '''
+  String get mainPrologue => '''
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
@@ -338,7 +338,7 @@ MessageLookupByLibrary$orNull _findGeneratedMessagesFor(String locale) {
 ''';
 
   /// Constant string used in [generateMainImportFile] as the end of the file.
-  get closing => '';
+  String get closing => '';
 }
 
 /// Message generator that parses translations from a `Map<String, dynamic>`.
@@ -368,14 +368,14 @@ import '${generatedFilePrefix}messages_all.dart' show evaluateJsonTemplate;
       Iterable<TranslatedMessage> usableTranslations, String locale);
 
   @override
-  get mainPrologue =>
+  String get mainPrologue =>
       super.mainPrologue +
       """
 import 'package:$intlImportPath/intl.dart';
 """;
 
   @override
-  get closing =>
+  String get closing =>
       super.closing +
       '''
 /// Turn the JSON template into a string.
@@ -451,7 +451,7 @@ String$orNull evaluateJsonTemplate(dynamic input, List<dynamic> args) {
 
   /// Constant string used in [generateFlutterImportFile] for the beginning of
   /// the file.
-  get flutterPrologue => """
+  String get flutterPrologue => """
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
@@ -715,13 +715,13 @@ abstract class TranslatedMessage {
   Message get message => translated;
 
   @override
-  toString() => id.toString();
+  String toString() => id.toString();
 
   @override
   bool operator ==(other) => other is TranslatedMessage && other.id == id;
 
   @override
-  get hashCode => id.hashCode;
+  int get hashCode => id.hashCode;
 }
 
 /// We can't use a hyphen in a Dart library name, so convert the locale

--- a/lib/src/arb_generation.dart
+++ b/lib/src/arb_generation.dart
@@ -8,10 +8,10 @@ import 'package:intl_translation/src/intl_message.dart';
 /// the translation file format into a Dart interpolation. In our case we
 /// store it to the file in Dart interpolation syntax, so the transformation
 /// is trivial.
-String leaveTheInterpolationsInDartForm(MainMessage msg, chunk) {
+String leaveTheInterpolationsInDartForm(MainMessage msg, dynamic chunk) {
   if (chunk is String) return chunk;
   if (chunk is int) return '\$${msg.arguments[chunk]}';
-  return chunk.toCode();
+  return (chunk as Message).toCode();
 }
 
 /// Convert the [MainMessage] to a trivial JSON format.
@@ -63,7 +63,7 @@ void addArgumentFor(MainMessage message, String arg, Map result) {
 String icuForm(MainMessage message) =>
     message.expanded(turnInterpolationIntoICUForm);
 
-String turnInterpolationIntoICUForm(Message message, chunk,
+String turnInterpolationIntoICUForm(Message message, dynamic chunk,
     {bool shouldEscapeICU = false}) {
   if (chunk is String) {
     return shouldEscapeICU ? escape(chunk) : chunk;

--- a/lib/src/arb_generation.dart
+++ b/lib/src/arb_generation.dart
@@ -64,7 +64,7 @@ String icuForm(MainMessage message) =>
     message.expanded(turnInterpolationIntoICUForm);
 
 String turnInterpolationIntoICUForm(Message message, chunk,
-    {bool shouldEscapeICU: false}) {
+    {bool shouldEscapeICU = false}) {
   if (chunk is String) {
     return shouldEscapeICU ? escape(chunk) : chunk;
   }

--- a/lib/src/arb_generation.dart
+++ b/lib/src/arb_generation.dart
@@ -10,7 +10,7 @@ import 'package:intl_translation/src/intl_message.dart';
 /// is trivial.
 String leaveTheInterpolationsInDartForm(MainMessage msg, chunk) {
   if (chunk is String) return chunk;
-  if (chunk is int) return "\$${msg.arguments[chunk]}";
+  if (chunk is int) return '\$${msg.arguments[chunk]}';
   return chunk.toCode();
 }
 
@@ -25,10 +25,10 @@ Map toARB(
   out[message.name] = icuForm(message);
 
   if (!supressMetadata) {
-    out["@${message.name}"] = arbMetadata(message);
+    out['@${message.name}'] = arbMetadata(message);
 
     if (includeSourceText) {
-      out["@${message.name}"]["source_text"] = out[message.name];
+      out['@${message.name}']['source_text'] = out[message.name];
     }
   }
 
@@ -39,21 +39,21 @@ Map arbMetadata(MainMessage message) {
   var out = {};
   var desc = message.description;
   if (desc != null) {
-    out["description"] = desc;
+    out['description'] = desc;
   }
-  out["type"] = "text";
+  out['type'] = 'text';
   var placeholders = {};
   for (var arg in message.arguments) {
     addArgumentFor(message, arg, placeholders);
   }
-  out["placeholders"] = placeholders;
+  out['placeholders'] = placeholders;
   return out;
 }
 
 void addArgumentFor(MainMessage message, String arg, Map result) {
   var extraInfo = {};
   if (message.examples != null && message.examples[arg] != null) {
-    extraInfo["example"] = message.examples[arg];
+    extraInfo['example'] = message.examples[arg];
   }
   result[arg] = extraInfo;
 }
@@ -69,7 +69,7 @@ String turnInterpolationIntoICUForm(Message message, chunk,
     return shouldEscapeICU ? escape(chunk) : chunk;
   }
   if (chunk is int && chunk >= 0 && chunk < message.arguments.length) {
-    return "{${message.arguments[chunk]}}";
+    return '{${message.arguments[chunk]}}';
   }
   if (chunk is SubMessage) {
     return chunk.expanded((message, chunk) =>
@@ -80,9 +80,9 @@ String turnInterpolationIntoICUForm(Message message, chunk,
         message, chunk,
         shouldEscapeICU: shouldEscapeICU));
   }
-  throw new FormatException("Illegal interpolation: $chunk");
+  throw FormatException('Illegal interpolation: $chunk');
 }
 
 String escape(String s) {
-  return s.replaceAll("'", "''").replaceAll("{", "'{'").replaceAll("}", "'}'");
+  return s.replaceAll("'", "''").replaceAll('{', "'{'").replaceAll('}', "'}'");
 }

--- a/lib/src/icu_parser.dart
+++ b/lib/src/icu_parser.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: avoid_dynamic_calls
+
 /// Contains a parser for ICU format plural/gender/select format for localized
 /// messages. See extract_to_arb.dart and make_hardcoded_translation.dart.
 library icu_parser;
@@ -42,7 +44,7 @@ class IcuParser {
       ['=0', '=1', '=2', 'zero', 'one', 'two', 'few', 'many', 'other']);
   Parser get genderKeyword => asKeywords(['female', 'male', 'other']);
 
-  var interiorText = undefined();
+  SettableParser interiorText = undefined();
 
   Parser get preface => (openCurly & id & comma).map((values) => values[1]);
 

--- a/lib/src/intl_message.dart
+++ b/lib/src/intl_message.dart
@@ -350,9 +350,13 @@ class CompositeMessage extends Message {
   CompositeMessage(this.pieces, ComplexMessage parent) : super(parent) {
     pieces.forEach((x) => x.parent = this);
   }
+  @override
   toCode() => pieces.map((each) => each.toCode()).join('');
+  @override
   toJson() => pieces.map((each) => each.toJson()).toList();
+  @override
   toString() => 'CompositeMessage(' + pieces.toString() + ')';
+  @override
   String expanded([Function f = _nullTransform]) =>
       pieces.map((chunk) => f(this, chunk)).join('');
 }
@@ -361,9 +365,13 @@ class CompositeMessage extends Message {
 class LiteralString extends Message {
   String string;
   LiteralString(this.string, Message parent) : super(parent);
+  @override
   toCode() => escapeAndValidateString(string);
+  @override
   toJson() => string;
+  @override
   toString() => 'Literal($string)';
+  @override
   String expanded([Function f = _nullTransform]) => f(this, string);
 }
 
@@ -414,9 +422,13 @@ class VariableSubstitution extends Message {
   // Although we only allow simple variable references, we always enclose them
   // in curly braces so that there's no possibility of ambiguity with
   // surrounding text.
+  @override
   toCode() => '\${${variableName}}';
+  @override
   toJson() => index;
+  @override
   toString() => 'VariableSubstitution($index)';
+  @override
   String expanded([Function f = _nullTransform]) => f(this, index);
 }
 
@@ -438,6 +450,7 @@ class MainMessage extends ComplexMessage {
   List<String> documentation = [];
 
   /// Verify that this looks like a correct Intl.message invocation.
+  @override
   String checkValidity(MethodInvocation node, List arguments, String outerName,
       List<FormalParameter> outerArgs,
       {bool nameAndArgsGenerated: false, bool examplesRequired: false}) {
@@ -467,6 +480,7 @@ class MainMessage extends ComplexMessage {
   String description;
 
   /// The examples from the Intl.message call
+  @override
   Map<String, dynamic> examples;
 
   /// A field to disambiguate two messages that might have exactly the
@@ -483,6 +497,7 @@ class MainMessage extends ComplexMessage {
   String id;
 
   /// The arguments list from the Intl.message call.
+  @override
   List<String> arguments;
 
   /// The locale argument from the Intl.message call
@@ -501,6 +516,7 @@ class MainMessage extends ComplexMessage {
 
   /// If the message was not given a name, we use the entire message string as
   /// the name.
+  @override
   String get name => _name ?? '';
   set name(String newName) {
     _name = newName;
@@ -514,6 +530,7 @@ class MainMessage extends ComplexMessage {
   /// either a String, an int or an object representing a more complex
   /// message entity.
   /// See [messagePieces].
+  @override
   String expanded([Function f = _nullTransform]) =>
       messagePieces.map((chunk) => f(this, chunk)).join('');
 
@@ -525,8 +542,10 @@ class MainMessage extends ComplexMessage {
     jsonTranslations[locale] = translated.toJson();
   }
 
+  @override
   toCode() =>
       throw UnsupportedError('MainMessage.toCode requires a locale');
+  @override
   toJson() =>
       throw UnsupportedError('MainMessage.toJson requires a locale');
 
@@ -582,6 +601,7 @@ class MainMessage extends ComplexMessage {
 
   /// The AST node will have the attribute names as strings, so we translate
   /// between those and the fields of the class.
+  @override
   void operator []=(String attributeName, value) {
     switch (attributeName) {
       case 'desc':
@@ -613,6 +633,7 @@ class MainMessage extends ComplexMessage {
 
   /// The AST node will have the attribute names as strings, so we translate
   /// between those and the fields of the class.
+  @override
   operator [](String attributeName) {
     switch (attributeName) {
       case 'desc':
@@ -635,14 +656,18 @@ class MainMessage extends ComplexMessage {
   }
 
   // This is the top-level construct, so there's no meaningful ICU name.
+  @override
   get icuMessageName => '';
 
+  @override
   get dartMessageName => 'message';
 
   /// The parameters that the Intl.message call may provide.
+  @override
   get attributeNames =>
       const ['name', 'desc', 'examples', 'args', 'meaning', 'skip'];
 
+  @override
   String toString() =>
       'Intl.message(${expanded()}, $name, $description, $examples, $arguments)';
 }
@@ -661,6 +686,7 @@ abstract class SubMessage extends ComplexMessage {
     }
   }
 
+  @override
   toString() => expanded();
 
   /// The name of the main argument, which is expected to have the value which
@@ -682,6 +708,7 @@ abstract class SubMessage extends ComplexMessage {
   ///  that map to the same clause.
   List<String> get codeAttributeNames;
 
+  @override
   String expanded([Function transform = _nullTransform]) {
     fullMessageForClause(String key) =>
         key + '{' + transform(parent, this[key]).toString() + '}';
@@ -692,6 +719,7 @@ abstract class SubMessage extends ComplexMessage {
     return "{$mainArgument,$icuMessageName, ${clauses.join("")}}";
   }
 
+  @override
   String toCode() {
     var out = StringBuffer();
     out.write('\${');
@@ -710,6 +738,7 @@ abstract class SubMessage extends ComplexMessage {
   /// for a plural), and then the values of all the possible arguments, in the
   /// order that they appear in codeAttributeNames. Any missing arguments are
   /// saved as an explicit null.
+  @override
   toJson() {
     var json = [];
     json.add(dartMessageName);
@@ -738,14 +767,19 @@ class Gender extends SubMessage {
   Message male;
   Message other;
 
+  @override
   String get icuMessageName => 'select';
+  @override
   String get dartMessageName => 'Intl.gender';
 
+  @override
   get attributeNames => ['female', 'male', 'other'];
+  @override
   get codeAttributeNames => attributeNames;
 
   /// The node will have the attribute names as strings, so we translate
   /// between those and the fields of the class.
+  @override
   void operator []=(String attributeName, rawValue) {
     var value = Message.from(rawValue, this);
     switch (attributeName) {
@@ -763,6 +797,7 @@ class Gender extends SubMessage {
     }
   }
 
+  @override
   Message operator [](String attributeName) {
     switch (attributeName) {
       case 'female':
@@ -789,14 +824,19 @@ class Plural extends SubMessage {
   Message many;
   Message other;
 
+  @override
   String get icuMessageName => 'plural';
+  @override
   String get dartMessageName => 'Intl.plural';
 
+  @override
   get attributeNames => ['=0', '=1', '=2', 'few', 'many', 'other'];
+  @override
   get codeAttributeNames => ['zero', 'one', 'two', 'few', 'many', 'other'];
 
   /// The node will have the attribute names as strings, so we translate
   /// between those and the fields of the class.
+  @override
   void operator []=(String attributeName, rawValue) {
     var value = Message.from(rawValue, this);
     switch (attributeName) {
@@ -838,6 +878,7 @@ class Plural extends SubMessage {
     }
   }
 
+  @override
   Message operator [](String attributeName) {
     switch (attributeName) {
       case 'zero':
@@ -879,10 +920,14 @@ class Select extends SubMessage {
 
   Map<String, Message> cases = Map<String, Message>();
 
+  @override
   String get icuMessageName => 'select';
+  @override
   String get dartMessageName => 'Intl.select';
 
+  @override
   get attributeNames => cases.keys.toList();
+  @override
   get codeAttributeNames => attributeNames;
 
   // Check for valid select keys.
@@ -890,6 +935,7 @@ class Select extends SubMessage {
   static const selectPattern = '[a-zA-Z][a-zA-Z0-9_-]*';
   static final validSelectKey = RegExp(selectPattern);
 
+  @override
   void operator []=(String attributeName, rawValue) {
     var value = Message.from(rawValue, this);
     if (validSelectKey.stringMatch(attributeName) == attributeName) {
@@ -901,6 +947,7 @@ class Select extends SubMessage {
     }
   }
 
+  @override
   Message operator [](String attributeName) {
     var exact = cases[attributeName];
     return exact == null ? cases['other'] : exact;
@@ -909,6 +956,7 @@ class Select extends SubMessage {
   /// Return the arguments that we care about for the select. In this
   /// case they will all be passed in as a Map rather than as the named
   /// arguments used in Plural/Gender.
+  @override
   Map argumentsOfInterestFor(MethodInvocation node) {
     SetOrMapLiteral casesArgument = node.argumentList.arguments[1];
     return Map.fromIterable(casesArgument.elements,
@@ -923,6 +971,7 @@ class Select extends SubMessage {
     return (key is SimpleStringLiteral) ? key.value : '$key'.split('.').last;
   }
 
+  @override
   void validate() {
     if (this['other'] == null) {
       throw IntlMessageExtractionException(
@@ -933,6 +982,7 @@ class Select extends SubMessage {
   /// Write out the generated representation of this message. This differs
   /// from Plural/Gender in that it prints a literal map rather than
   /// named arguments.
+  @override
   String toCode() {
     var out = StringBuffer();
     out.write('\${');
@@ -950,6 +1000,7 @@ class Select extends SubMessage {
   /// We represent this in JSON as a List with the name of the message
   /// (e.g. Intl.select), the index in the arguments list of the main argument,
   /// and then a Map from the cases to the List of strings or sub-messages.
+  @override
   toJson() {
     var json = [];
     json.add(dartMessageName);
@@ -971,5 +1022,6 @@ class IntlMessageExtractionException implements Exception {
   /// Creates a new exception with an optional error [message].
   const IntlMessageExtractionException([this.message = '']);
 
+  @override
   String toString() => 'IntlMessageExtractionException: $message';
 }

--- a/lib/src/intl_message.dart
+++ b/lib/src/intl_message.dart
@@ -39,7 +39,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/src/dart/ast/constant_evaluator.dart';
 
 /// A default function for the [Message.expanded] method.
-_nullTransform(msg, chunk) => chunk;
+dynamic _nullTransform(msg, chunk) => chunk;
 
 const jsonEncoder = JsonCodec();
 
@@ -58,12 +58,12 @@ abstract class Message {
   /// We find the arguments from the top-level [MainMessage] and use those to
   /// do variable substitutions. [MainMessage] overrides this to return
   /// the actual arguments.
-  get arguments => parent == null ? const [] : parent.arguments;
+  dynamic get arguments => parent == null ? const [] : parent.arguments;
 
   /// We find the examples from the top-level [MainMessage] and use those
   /// when writing out variables. [MainMessage] overrides this to return
   /// the actual examples.
-  get examples => parent == null ? const [] : parent.examples;
+  dynamic get examples => parent == null ? const [] : parent.examples;
 
   /// The name of the top-level [MainMessage].
   String get name => parent == null ? '<unnamed>' : parent.name;
@@ -324,7 +324,7 @@ abstract class ComplexMessage extends Message {
   /// and set their attributes by string names, so we override the indexing
   /// operators so that they behave like maps with respect to those attribute
   /// names.
-  operator [](String attributeName);
+  dynamic operator [](String attributeName);
 
   /// When we create these from strings or from AST nodes, we want to look up
   /// and set their attributes by string names, so we override the indexing
@@ -355,11 +355,11 @@ class CompositeMessage extends Message {
     }
   }
   @override
-  toCode() => pieces.map((each) => each.toCode()).join('');
+  String toCode() => pieces.map((each) => each.toCode()).join('');
   @override
-  toJson() => pieces.map((each) => each.toJson()).toList();
+  List<Object> toJson() => pieces.map((each) => each.toJson()).toList();
   @override
-  toString() => 'CompositeMessage(' + pieces.toString() + ')';
+  String toString() => 'CompositeMessage(' + pieces.toString() + ')';
   @override
   String expanded([Function transform = _nullTransform]) =>
       pieces.map((chunk) => transform(this, chunk)).join('');
@@ -370,11 +370,11 @@ class LiteralString extends Message {
   String string;
   LiteralString(this.string, Message parent) : super(parent);
   @override
-  toCode() => escapeAndValidateString(string);
+  String toCode() => escapeAndValidateString(string);
   @override
-  toJson() => string;
+  String toJson() => string;
   @override
-  toString() => 'Literal($string)';
+  String toString() => 'Literal($string)';
   @override
   String expanded([Function transform = _nullTransform]) =>
       transform(this, string);
@@ -428,11 +428,11 @@ class VariableSubstitution extends Message {
   // in curly braces so that there's no possibility of ambiguity with
   // surrounding text.
   @override
-  toCode() => '\${$variableName}';
+  String toCode() => '\${$variableName}';
   @override
-  toJson() => index;
+  int toJson() => index;
   @override
-  toString() => 'VariableSubstitution($index)';
+  String toString() => 'VariableSubstitution($index)';
   @override
   String expanded([Function transform = _nullTransform]) =>
       transform(this, index);
@@ -549,9 +549,12 @@ class MainMessage extends ComplexMessage {
   }
 
   @override
-  toCode() => throw UnsupportedError('MainMessage.toCode requires a locale');
+  String toCode() =>
+      throw UnsupportedError('MainMessage.toCode requires a locale');
+
   @override
-  toJson() => throw UnsupportedError('MainMessage.toJson requires a locale');
+  String toJson() =>
+      throw UnsupportedError('MainMessage.toJson requires a locale');
 
   /// Generate code for this message, expecting it to be part of a map
   /// keyed by name with values the function that calls Intl.message.
@@ -566,11 +569,11 @@ class MainMessage extends ComplexMessage {
   }
 
   /// Return a JSON string representation of this message.
-  toJsonForLocale(String locale) {
+  Object toJsonForLocale(String locale) {
     return jsonTranslations[locale];
   }
 
-  turnInterpolationBackIntoStringForm(Message message, chunk) {
+  String turnInterpolationBackIntoStringForm(Message message, chunk) {
     if (chunk is String) return escapeAndValidateString(chunk);
     if (chunk is int) return r'${' + message.arguments[chunk] + '}';
     if (chunk is Message) return chunk.toCode();
@@ -638,7 +641,7 @@ class MainMessage extends ComplexMessage {
   /// The AST node will have the attribute names as strings, so we translate
   /// between those and the fields of the class.
   @override
-  operator [](String attributeName) {
+  dynamic operator [](String attributeName) {
     switch (attributeName) {
       case 'desc':
         return description;
@@ -661,14 +664,14 @@ class MainMessage extends ComplexMessage {
 
   // This is the top-level construct, so there's no meaningful ICU name.
   @override
-  get icuMessageName => '';
+  String get icuMessageName => '';
 
   @override
-  get dartMessageName => 'message';
+  String get dartMessageName => 'message';
 
   /// The parameters that the Intl.message call may provide.
   @override
-  get attributeNames =>
+  List<String> get attributeNames =>
       const ['name', 'desc', 'examples', 'args', 'meaning', 'skip'];
 
   @override
@@ -691,7 +694,7 @@ abstract class SubMessage extends ComplexMessage {
   }
 
   @override
-  toString() => expanded();
+  String toString() => expanded();
 
   /// The name of the main argument, which is expected to have the value which
   /// is one of [attributeNames] and is used to decide which clause to use.
@@ -714,7 +717,7 @@ abstract class SubMessage extends ComplexMessage {
 
   @override
   String expanded([Function transform = _nullTransform]) {
-    fullMessageForClause(String key) =>
+    String fullMessageForClause(String key) =>
         key + '{' + transform(parent, this[key]).toString() + '}';
     var clauses = attributeNames
         .where((key) => this[key] != null)
@@ -743,7 +746,7 @@ abstract class SubMessage extends ComplexMessage {
   /// order that they appear in codeAttributeNames. Any missing arguments are
   /// saved as an explicit null.
   @override
-  toJson() {
+  List toJson() {
     var json = [];
     json.add(dartMessageName);
     json.add(arguments.indexOf(mainArgument));
@@ -777,9 +780,9 @@ class Gender extends SubMessage {
   String get dartMessageName => 'Intl.gender';
 
   @override
-  get attributeNames => ['female', 'male', 'other'];
+  List<String> get attributeNames => ['female', 'male', 'other'];
   @override
-  get codeAttributeNames => attributeNames;
+  List<String> get codeAttributeNames => attributeNames;
 
   /// The node will have the attribute names as strings, so we translate
   /// between those and the fields of the class.
@@ -834,9 +837,10 @@ class Plural extends SubMessage {
   String get dartMessageName => 'Intl.plural';
 
   @override
-  get attributeNames => ['=0', '=1', '=2', 'few', 'many', 'other'];
+  List<String> get attributeNames => ['=0', '=1', '=2', 'few', 'many', 'other'];
   @override
-  get codeAttributeNames => ['zero', 'one', 'two', 'few', 'many', 'other'];
+  List<String> get codeAttributeNames =>
+      ['zero', 'one', 'two', 'few', 'many', 'other'];
 
   /// The node will have the attribute names as strings, so we translate
   /// between those and the fields of the class.
@@ -930,9 +934,9 @@ class Select extends SubMessage {
   String get dartMessageName => 'Intl.select';
 
   @override
-  get attributeNames => cases.keys.toList();
+  List<String> get attributeNames => cases.keys.toList();
   @override
-  get codeAttributeNames => attributeNames;
+  List<String> get codeAttributeNames => attributeNames;
 
   // Check for valid select keys.
   // See http://site.icu-project.org/design/formatting/select
@@ -1009,7 +1013,7 @@ class Select extends SubMessage {
   /// (e.g. Intl.select), the index in the arguments list of the main argument,
   /// and then a Map from the cases to the List of strings or sub-messages.
   @override
-  toJson() {
+  List toJson() {
     var json = [];
     json.add(dartMessageName);
     json.add(arguments.indexOf(mainArgument));

--- a/lib/src/intl_message.dart
+++ b/lib/src/intl_message.dart
@@ -304,9 +304,10 @@ abstract class Message {
       r'$': r'\$'
     };
 
-    String _escape(String s) => escapes[s] ?? s;
-
-    var escaped = value.splitMapJoin('', onNonMatch: _escape);
+    var escaped = value.splitMapJoin(
+      '',
+      onNonMatch: (String string) => escapes[string] ?? string,
+    );
     return escaped;
   }
 
@@ -360,7 +361,7 @@ class CompositeMessage extends Message {
   @override
   List<Object> toJson() => pieces.map((each) => each.toJson()).toList();
   @override
-  String toString() => 'CompositeMessage(' + pieces.toString() + ')';
+  String toString() => 'CompositeMessage($pieces)';
   @override
   String expanded([Function transform = _nullTransform]) =>
       pieces.map((chunk) => transform(this, chunk)).join('');
@@ -576,7 +577,7 @@ class MainMessage extends ComplexMessage {
 
   String turnInterpolationBackIntoStringForm(Message message, dynamic chunk) {
     if (chunk is String) return escapeAndValidateString(chunk);
-    if (chunk is int) return r'${' + message.arguments[chunk] + '}';
+    if (chunk is int) return r'${message.arguments[chunk]}';
     if (chunk is Message) return chunk.toCode();
     throw ArgumentError.value(chunk, 'Unexpected value in Intl.message');
   }
@@ -720,7 +721,7 @@ abstract class SubMessage extends ComplexMessage {
   @override
   String expanded([Function transform = _nullTransform]) {
     String fullMessageForClause(String key) =>
-        key + '{' + transform(parent, this[key]).toString() + '}';
+        '$key{${transform(parent, this[key])}}';
     var clauses = attributeNames
         .where((key) => this[key] != null)
         .map(fullMessageForClause)

--- a/lib/src/intl_message.dart
+++ b/lib/src/intl_message.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: implementation_imports
+
 /// This provides classes to represent the internal structure of the
 /// arguments to `Intl.message`. It is used when parsing sources to extract
 /// messages or to generate code for message substitution. Normal programs
@@ -543,11 +545,9 @@ class MainMessage extends ComplexMessage {
   }
 
   @override
-  toCode() =>
-      throw UnsupportedError('MainMessage.toCode requires a locale');
+  toCode() => throw UnsupportedError('MainMessage.toCode requires a locale');
   @override
-  toJson() =>
-      throw UnsupportedError('MainMessage.toJson requires a locale');
+  toJson() => throw UnsupportedError('MainMessage.toJson requires a locale');
 
   /// Generate code for this message, expecting it to be part of a map
   /// keyed by name with values the function that calls Intl.message.

--- a/lib/src/intl_message.dart
+++ b/lib/src/intl_message.dart
@@ -39,7 +39,7 @@ import 'package:analyzer/src/dart/ast/constant_evaluator.dart';
 /// A default function for the [Message.expanded] method.
 _nullTransform(msg, chunk) => chunk;
 
-const jsonEncoder = const JsonCodec();
+const jsonEncoder = JsonCodec();
 
 /// An abstract superclass for Intl.message/plural/gender calls in the
 /// program's source text. We
@@ -66,7 +66,7 @@ abstract class Message {
   /// The name of the top-level [MainMessage].
   String get name => parent == null ? '<unnamed>' : parent.name;
 
-  static final _evaluator = new ConstantEvaluator();
+  static final _evaluator = ConstantEvaluator();
 
   String _evaluateAsString(expression) {
     var result = expression.accept(_evaluator);
@@ -101,7 +101,7 @@ abstract class Message {
         .toList();
     Map<String, String> both;
     try {
-      both = new Map.fromIterables(names, parameterNames);
+      both = Map.fromIterables(names, parameterNames);
     } catch (e) {
       // Most likely because sizes don't match.
       return false;
@@ -142,11 +142,11 @@ abstract class Message {
     var hasParameters = outerArgs.isNotEmpty;
     if (!nameAndArgsGenerated && !hasArgs && hasParameters) {
       return "The 'args' argument for Intl.message must be specified for "
-          "messages with parameters. Consider using rewrite_intl_messages.dart";
+          'messages with parameters. Consider using rewrite_intl_messages.dart';
     }
     if (!checkArgs(args, parameterNames)) {
       return "The 'args' argument must match the message arguments,"
-          " e.g. args: ${parameterNames}";
+          ' e.g. args: ${parameterNames}';
     }
     var messageNameArgument = arguments.firstWhere(
         (eachArg) =>
@@ -171,8 +171,8 @@ abstract class Message {
           messageName = givenName;
         } else {
           return "The 'name' argument for Intl.message must be supplied for "
-              "messages with parameters. Consider using "
-              "rewrite_intl_messages.dart";
+              'messages with parameters. Consider using '
+              'rewrite_intl_messages.dart';
         }
       }
     } else {
@@ -192,35 +192,35 @@ abstract class Message {
     var classMatch = classPlusMethod != null && (givenName == classPlusMethod);
     if (!(hasOuterName && (simpleMatch || classMatch))) {
       return "The 'name' argument for Intl.message must match either "
-          "the name of the containing function or <ClassName>_<methodName> ("
+          'the name of the containing function or <ClassName>_<methodName> ('
           "was '$givenName' but must be '$outerName'  or '$classPlusMethod')";
     }
 
     var simpleArguments = arguments.where((each) =>
         each is NamedExpression &&
-        ["desc", "name"].contains(each.name.label.name));
+        ['desc', 'name'].contains(each.name.label.name));
     var values = simpleArguments.map((each) => each.expression).toList();
     for (var arg in values) {
       if (_evaluateAsString(arg) == null) {
-        return ("Intl.message arguments must be string literals: $arg");
+        return ('Intl.message arguments must be string literals: $arg');
       }
     }
 
     if (hasParameters) {
       var exampleArg = arguments.where((each) =>
-          each is NamedExpression && each.name.label.name == "examples");
+          each is NamedExpression && each.name.label.name == 'examples');
       var examples = exampleArg.map((each) => each.expression).toList();
       if (examples.isEmpty && examplesRequired) {
-        return "Examples must be provided for messages with parameters";
+        return 'Examples must be provided for messages with parameters';
       }
       if (examples.isNotEmpty) {
         var example = examples.first;
         var map = _evaluateAsMap(example);
         if (map == null) {
-          return "Examples must be a const Map literal.";
+          return 'Examples must be a const Map literal.';
         }
         if (example.constKeyword == null) {
-          return "Examples must be const.";
+          return 'Examples must be const.';
         }
       }
     }
@@ -254,7 +254,7 @@ abstract class Message {
     var classDeclaration = classNode(node);
     return classDeclaration == null
         ? null
-        : "${classDeclaration.name.token}_$outerName";
+        : '${classDeclaration.name.token}_$outerName';
   }
 
   /// Turn a value, typically read from a translation file or created out of an
@@ -263,11 +263,11 @@ abstract class Message {
   /// represented by integers, things that are already MessageChunks and
   /// lists of the same.
   static Message from(Object value, Message parent) {
-    if (value is String) return new LiteralString(value, parent);
-    if (value is int) return new VariableSubstitution(value, parent);
+    if (value is String) return LiteralString(value, parent);
+    if (value is int) return VariableSubstitution(value, parent);
     if (value is List) {
       if (value.length == 1) return Message.from(value[0], parent);
-      var result = new CompositeMessage([], parent);
+      var result = CompositeMessage([], parent);
       var items = value.map((x) => from(x, result)).toList();
       result.pieces.addAll(items);
       return result;
@@ -288,22 +288,22 @@ abstract class Message {
 
   /// Escape the string for use in generated Dart code.
   String escapeAndValidateString(String value) {
-    const Map<String, String> escapes = const {
-      r"\": r"\\",
+    const Map<String, String> escapes = {
+      r'\': r'\\',
       '"': r'\"',
-      "\b": r"\b",
-      "\f": r"\f",
-      "\n": r"\n",
-      "\r": r"\r",
-      "\t": r"\t",
-      "\v": r"\v",
+      '\b': r'\b',
+      '\f': r'\f',
+      '\n': r'\n',
+      '\r': r'\r',
+      '\t': r'\t',
+      '\v': r'\v',
       "'": r"\'",
-      r"$": r"\$"
+      r'$': r'\$'
     };
 
     String _escape(String s) => escapes[s] ?? s;
 
-    var escaped = value.splitMapJoin("", onNonMatch: _escape);
+    var escaped = value.splitMapJoin('', onNonMatch: _escape);
     return escaped;
   }
 
@@ -352,9 +352,9 @@ class CompositeMessage extends Message {
   }
   toCode() => pieces.map((each) => each.toCode()).join('');
   toJson() => pieces.map((each) => each.toJson()).toList();
-  toString() => "CompositeMessage(" + pieces.toString() + ")";
+  toString() => 'CompositeMessage(' + pieces.toString() + ')';
   String expanded([Function f = _nullTransform]) =>
-      pieces.map((chunk) => f(this, chunk)).join("");
+      pieces.map((chunk) => f(this, chunk)).join('');
 }
 
 /// Represents a simple constant string with no dynamic elements.
@@ -363,7 +363,7 @@ class LiteralString extends Message {
   LiteralString(this.string, Message parent) : super(parent);
   toCode() => escapeAndValidateString(string);
   toJson() => string;
-  toString() => "Literal($string)";
+  toString() => 'Literal($string)';
   String expanded([Function f = _nullTransform]) => f(this, string);
 }
 
@@ -394,10 +394,10 @@ class VariableSubstitution extends Message {
         .toList()
         .indexOf(_variableNameUpper);
     if (_index == -1) {
-      throw new ArgumentError(
+      throw ArgumentError(
           "Cannot find parameter named '$_variableNameUpper' in "
           "message named '$name'. Available "
-          "parameters are $arguments");
+          'parameters are $arguments');
     }
     return _index;
   }
@@ -414,9 +414,9 @@ class VariableSubstitution extends Message {
   // Although we only allow simple variable references, we always enclose them
   // in curly braces so that there's no possibility of ambiguity with
   // surrounding text.
-  toCode() => "\${${variableName}}";
+  toCode() => '\${${variableName}}';
   toJson() => index;
-  toString() => "VariableSubstitution($index)";
+  toString() => 'VariableSubstitution($index)';
   String expanded([Function f = _nullTransform]) => f(this, index);
 }
 
@@ -442,7 +442,7 @@ class MainMessage extends ComplexMessage {
       List<FormalParameter> outerArgs,
       {bool nameAndArgsGenerated: false, bool examplesRequired: false}) {
     if (arguments.first is! StringLiteral) {
-      return "Intl.message messages must be string literals";
+      return 'Intl.message messages must be string literals';
     }
 
     return super.checkValidity(node, arguments, outerName, outerArgs,
@@ -458,8 +458,8 @@ class MainMessage extends ComplexMessage {
 
   void validateDescription() {
     if (description == null || description == '') {
-      throw new IntlMessageExtractionException(
-          "Missing description for message $this");
+      throw IntlMessageExtractionException(
+          'Missing description for message $this');
     }
   }
 
@@ -501,7 +501,7 @@ class MainMessage extends ComplexMessage {
 
   /// If the message was not given a name, we use the entire message string as
   /// the name.
-  String get name => _name ?? "";
+  String get name => _name ?? '';
   set name(String newName) {
     _name = newName;
   }
@@ -515,7 +515,7 @@ class MainMessage extends ComplexMessage {
   /// message entity.
   /// See [messagePieces].
   String expanded([Function f = _nullTransform]) =>
-      messagePieces.map((chunk) => f(this, chunk)).join("");
+      messagePieces.map((chunk) => f(this, chunk)).join('');
 
   /// Record the translation for this message in the given locale, after
   /// suitably escaping it.
@@ -526,16 +526,16 @@ class MainMessage extends ComplexMessage {
   }
 
   toCode() =>
-      throw new UnsupportedError("MainMessage.toCode requires a locale");
+      throw UnsupportedError('MainMessage.toCode requires a locale');
   toJson() =>
-      throw new UnsupportedError("MainMessage.toJson requires a locale");
+      throw UnsupportedError('MainMessage.toJson requires a locale');
 
   /// Generate code for this message, expecting it to be part of a map
   /// keyed by name with values the function that calls Intl.message.
   String toCodeForLocale(String locale, String name) {
-    var out = new StringBuffer()
+    var out = StringBuffer()
       ..write('static $name(')
-      ..write(arguments.join(", "))
+      ..write(arguments.join(', '))
       ..write(') => "')
       ..write(translations[locale])
       ..write('";');
@@ -549,34 +549,34 @@ class MainMessage extends ComplexMessage {
 
   turnInterpolationBackIntoStringForm(Message message, chunk) {
     if (chunk is String) return escapeAndValidateString(chunk);
-    if (chunk is int) return r"${" + message.arguments[chunk] + "}";
+    if (chunk is int) return r'${' + message.arguments[chunk] + '}';
     if (chunk is Message) return chunk.toCode();
-    throw new ArgumentError.value(chunk, "Unexpected value in Intl.message");
+    throw ArgumentError.value(chunk, 'Unexpected value in Intl.message');
   }
 
   /// Create a string that will recreate this message, optionally
   /// including the compile-time only information desc and examples.
   String toOriginalCode({bool includeDesc: true, includeExamples: true}) {
-    var out = new StringBuffer()..write("Intl.message('");
+    var out = StringBuffer()..write("Intl.message('");
     out.write(expanded(turnInterpolationBackIntoStringForm));
     out.write("', ");
     out.write("name: '$name', ");
-    out.write(locale == null ? "" : "locale: '$locale', ");
+    out.write(locale == null ? '' : "locale: '$locale', ");
     if (includeDesc) {
       out.write(description == null
-          ? ""
+          ? ''
           : "desc: '${escapeAndValidateString(description)}', ");
     }
     if (includeExamples) {
       // json is already mostly-escaped, but we need to handle interpolations.
-      var json = jsonEncoder.encode(examples).replaceAll(r"$", r"\$");
-      out.write(examples == null ? "" : "examples: const ${json}, ");
+      var json = jsonEncoder.encode(examples).replaceAll(r'$', r'\$');
+      out.write(examples == null ? '' : 'examples: const ${json}, ');
     }
     out.write(meaning == null
-        ? ""
+        ? ''
         : "meaning: '${escapeAndValidateString(meaning)}', ");
     out.write("args: [${arguments.join(', ')}]");
-    out.write(")");
+    out.write(')');
     return out.toString();
   }
 
@@ -584,26 +584,26 @@ class MainMessage extends ComplexMessage {
   /// between those and the fields of the class.
   void operator []=(String attributeName, value) {
     switch (attributeName) {
-      case "desc":
+      case 'desc':
         description = value;
         return;
-      case "examples":
+      case 'examples':
         examples = value as Map<String, dynamic>;
         return;
-      case "name":
+      case 'name':
         name = value;
         return;
       // We use the actual args from the parser rather than what's given in the
       // arguments to Intl.message.
-      case "args":
+      case 'args':
         return;
-      case "meaning":
+      case 'meaning':
         meaning = value;
         return;
-      case "locale":
+      case 'locale':
         locale = value;
         return;
-      case "skip":
+      case 'skip':
         skip = value as bool;
         return;
       default:
@@ -615,19 +615,19 @@ class MainMessage extends ComplexMessage {
   /// between those and the fields of the class.
   operator [](String attributeName) {
     switch (attributeName) {
-      case "desc":
+      case 'desc':
         return description;
-      case "examples":
+      case 'examples':
         return examples;
-      case "name":
+      case 'name':
         return name;
       // We use the actual args from the parser rather than what's given in the
       // arguments to Intl.message.
-      case "args":
+      case 'args':
         return [];
-      case "meaning":
+      case 'meaning':
         return meaning;
-      case "skip":
+      case 'skip':
         return skip;
       default:
         return null;
@@ -637,14 +637,14 @@ class MainMessage extends ComplexMessage {
   // This is the top-level construct, so there's no meaningful ICU name.
   get icuMessageName => '';
 
-  get dartMessageName => "message";
+  get dartMessageName => 'message';
 
   /// The parameters that the Intl.message call may provide.
   get attributeNames =>
-      const ["name", "desc", "examples", "args", "meaning", "skip"];
+      const ['name', 'desc', 'examples', 'args', 'meaning', 'skip'];
 
   String toString() =>
-      "Intl.message(${expanded()}, $name, $description, $examples, $arguments)";
+      'Intl.message(${expanded()}, $name, $description, $examples, $arguments)';
 }
 
 /// An abstract class to represent sub-sections of a message, primarily
@@ -672,7 +672,7 @@ abstract class SubMessage extends ComplexMessage {
   Map argumentsOfInterestFor(MethodInvocation node) {
     var basicArguments = node.argumentList.arguments;
     var others = basicArguments.whereType<NamedExpression>();
-    return new Map.fromIterable(others,
+    return Map.fromIterable(others,
         key: (node) => node.name.label.token.value(),
         value: (node) => node.expression);
   }
@@ -693,7 +693,7 @@ abstract class SubMessage extends ComplexMessage {
   }
 
   String toCode() {
-    var out = new StringBuffer();
+    var out = StringBuffer();
     out.write('\${');
     out.write(dartMessageName);
     out.write('(');
@@ -701,7 +701,7 @@ abstract class SubMessage extends ComplexMessage {
     var args = codeAttributeNames.where((attribute) => this[attribute] != null);
     args.fold(
         out, (buffer, arg) => buffer..write(", $arg: '${this[arg].toCode()}'"));
-    out.write(")}");
+    out.write(')}');
     return out.toString();
   }
 
@@ -738,10 +738,10 @@ class Gender extends SubMessage {
   Message male;
   Message other;
 
-  String get icuMessageName => "select";
+  String get icuMessageName => 'select';
   String get dartMessageName => 'Intl.gender';
 
-  get attributeNames => ["female", "male", "other"];
+  get attributeNames => ['female', 'male', 'other'];
   get codeAttributeNames => attributeNames;
 
   /// The node will have the attribute names as strings, so we translate
@@ -749,13 +749,13 @@ class Gender extends SubMessage {
   void operator []=(String attributeName, rawValue) {
     var value = Message.from(rawValue, this);
     switch (attributeName) {
-      case "female":
+      case 'female':
         female = value;
         return;
-      case "male":
+      case 'male':
         male = value;
         return;
-      case "other":
+      case 'other':
         other = value;
         return;
       default:
@@ -765,11 +765,11 @@ class Gender extends SubMessage {
 
   Message operator [](String attributeName) {
     switch (attributeName) {
-      case "female":
+      case 'female':
         return female;
-      case "male":
+      case 'male':
         return male;
-      case "other":
+      case 'other':
         return other;
       default:
         return other;
@@ -789,48 +789,48 @@ class Plural extends SubMessage {
   Message many;
   Message other;
 
-  String get icuMessageName => "plural";
-  String get dartMessageName => "Intl.plural";
+  String get icuMessageName => 'plural';
+  String get dartMessageName => 'Intl.plural';
 
-  get attributeNames => ["=0", "=1", "=2", "few", "many", "other"];
-  get codeAttributeNames => ["zero", "one", "two", "few", "many", "other"];
+  get attributeNames => ['=0', '=1', '=2', 'few', 'many', 'other'];
+  get codeAttributeNames => ['zero', 'one', 'two', 'few', 'many', 'other'];
 
   /// The node will have the attribute names as strings, so we translate
   /// between those and the fields of the class.
   void operator []=(String attributeName, rawValue) {
     var value = Message.from(rawValue, this);
     switch (attributeName) {
-      case "zero":
+      case 'zero':
         // We prefer an explicit "=0" clause to a "ZERO"
         // if both are present.
         if (zero == null) zero = value;
         return;
-      case "=0":
+      case '=0':
         zero = value;
         return;
-      case "one":
+      case 'one':
         // We prefer an explicit "=1" clause to a "ONE"
         // if both are present.
         if (one == null) one = value;
         return;
-      case "=1":
+      case '=1':
         one = value;
         return;
-      case "two":
+      case 'two':
         // We prefer an explicit "=2" clause to a "TWO"
         // if both are present.
         if (two == null) two = value;
         return;
-      case "=2":
+      case '=2':
         two = value;
         return;
-      case "few":
+      case 'few':
         few = value;
         return;
-      case "many":
+      case 'many':
         many = value;
         return;
-      case "other":
+      case 'other':
         other = value;
         return;
       default:
@@ -840,23 +840,23 @@ class Plural extends SubMessage {
 
   Message operator [](String attributeName) {
     switch (attributeName) {
-      case "zero":
+      case 'zero':
         return zero;
-      case "=0":
+      case '=0':
         return zero;
-      case "one":
+      case 'one':
         return one;
-      case "=1":
+      case '=1':
         return one;
-      case "two":
+      case 'two':
         return two;
-      case "=2":
+      case '=2':
         return two;
-      case "few":
+      case 'few':
         return few;
-      case "many":
+      case 'many':
         return many;
-      case "other":
+      case 'other':
         return other;
       default:
         return other;
@@ -877,9 +877,9 @@ class Select extends SubMessage {
   Select.from(String mainArgument, List clauses, Message parent)
       : super.from(mainArgument, clauses, parent);
 
-  Map<String, Message> cases = new Map<String, Message>();
+  Map<String, Message> cases = Map<String, Message>();
 
-  String get icuMessageName => "select";
+  String get icuMessageName => 'select';
   String get dartMessageName => 'Intl.select';
 
   get attributeNames => cases.keys.toList();
@@ -888,14 +888,14 @@ class Select extends SubMessage {
   // Check for valid select keys.
   // See http://site.icu-project.org/design/formatting/select
   static const selectPattern = '[a-zA-Z][a-zA-Z0-9_-]*';
-  static final validSelectKey = new RegExp(selectPattern);
+  static final validSelectKey = RegExp(selectPattern);
 
   void operator []=(String attributeName, rawValue) {
     var value = Message.from(rawValue, this);
     if (validSelectKey.stringMatch(attributeName) == attributeName) {
       cases[attributeName] = value;
     } else {
-      throw new IntlMessageExtractionException(
+      throw IntlMessageExtractionException(
           "Invalid select keyword: '$attributeName', must "
           "match '$selectPattern'");
     }
@@ -903,7 +903,7 @@ class Select extends SubMessage {
 
   Message operator [](String attributeName) {
     var exact = cases[attributeName];
-    return exact == null ? cases["other"] : exact;
+    return exact == null ? cases['other'] : exact;
   }
 
   /// Return the arguments that we care about for the select. In this
@@ -911,7 +911,7 @@ class Select extends SubMessage {
   /// arguments used in Plural/Gender.
   Map argumentsOfInterestFor(MethodInvocation node) {
     SetOrMapLiteral casesArgument = node.argumentList.arguments[1];
-    return new Map.fromIterable(casesArgument.elements,
+    return Map.fromIterable(casesArgument.elements,
         key: (node) => _keyForm(node.key), value: (node) => node.value);
   }
 
@@ -924,9 +924,9 @@ class Select extends SubMessage {
   }
 
   void validate() {
-    if (this["other"] == null) {
-      throw new IntlMessageExtractionException(
-          "Missing keyword other for Intl.select $this");
+    if (this['other'] == null) {
+      throw IntlMessageExtractionException(
+          'Missing keyword other for Intl.select $this');
     }
   }
 
@@ -934,16 +934,16 @@ class Select extends SubMessage {
   /// from Plural/Gender in that it prints a literal map rather than
   /// named arguments.
   String toCode() {
-    var out = new StringBuffer();
+    var out = StringBuffer();
     out.write('\${');
     out.write(dartMessageName);
     out.write('(');
     out.write(mainArgument);
     var args = codeAttributeNames;
-    out.write(", {");
+    out.write(', {');
     args.fold(out,
         (buffer, arg) => buffer..write("'$arg': '${this[arg].toCode()}', "));
-    out.write("})}");
+    out.write('})}');
     return out.toString();
   }
 
@@ -969,7 +969,7 @@ class IntlMessageExtractionException implements Exception {
   final String message;
 
   /// Creates a new exception with an optional error [message].
-  const IntlMessageExtractionException([this.message = ""]);
+  const IntlMessageExtractionException([this.message = '']);
 
-  String toString() => "IntlMessageExtractionException: $message";
+  String toString() => 'IntlMessageExtractionException: $message';
 }

--- a/lib/src/message_rewriter.dart
+++ b/lib/src/message_rewriter.dart
@@ -19,7 +19,7 @@ String rewriteMessages(String source, String sourceName,
   messages.sort((a, b) => a.sourcePosition.compareTo(b.sourcePosition));
 
   var start = 0;
-  var newSource = new StringBuffer();
+  var newSource = StringBuffer();
   for (var message in messages) {
     if (message.arguments.isNotEmpty) {
       newSource.write(source.substring(start, message.sourcePosition));
@@ -55,7 +55,7 @@ rewriteWithStringSubstitution(
   var hasName = originalSource.contains(nameCheck);
   var hasArgs = originalSource.contains(argsCheck);
   var withName = hasName ? '' : ",\nname: '${message.name}'";
-  var withArgs = hasArgs ? '' : ",\nargs: ${message.arguments}";
+  var withArgs = hasArgs ? '' : ',\nargs: ${message.arguments}';
   var nameAndArgs = "$withName$withArgs)";
   newSource.write(originalSource.substring(0, closingParen));
   newSource.write(nameAndArgs);
@@ -64,15 +64,15 @@ rewriteWithStringSubstitution(
   newSource.write(originalSource.substring(closingParen + 1));
 }
 
-final RegExp nameCheck = new RegExp('[\\n,]\\s+name\:');
-final RegExp argsCheck = new RegExp('[\\n,]\\s+args\:');
+final RegExp nameCheck = RegExp('[\\n,]\\s+name\:');
+final RegExp argsCheck = RegExp('[\\n,]\\s+args\:');
 
 /// Find all the messages in the [source] text.
 ///
 /// Report errors as coming from [sourceName]
 List<MainMessage> findMessages(String source, String sourceName,
     [MessageExtraction extraction]) {
-  extraction = extraction ?? new MessageExtraction();
+  extraction = extraction ?? MessageExtraction();
   try {
     var result = parseString(content: source);
     if (result.errors.isNotEmpty) {
@@ -82,12 +82,12 @@ List<MainMessage> findMessages(String source, String sourceName,
     extraction.root = result.unit;
   } on ArgumentError catch (e) {
     extraction
-        .onMessage("Error in parsing $sourceName, no messages extracted.");
-    extraction.onMessage("  $e");
+        .onMessage('Error in parsing $sourceName, no messages extracted.');
+    extraction.onMessage('  $e');
     return [];
   }
   extraction.origin = sourceName;
-  var visitor = new MessageFindingVisitor(extraction);
+  var visitor = MessageFindingVisitor(extraction);
   visitor.generateNameAndArgs = true;
   extraction.root.accept(visitor);
   return visitor.messages.values.toList();

--- a/lib/src/message_rewriter.dart
+++ b/lib/src/message_rewriter.dart
@@ -56,7 +56,7 @@ rewriteWithStringSubstitution(
   var hasArgs = originalSource.contains(argsCheck);
   var withName = hasName ? '' : ",\nname: '${message.name}'";
   var withArgs = hasArgs ? '' : ',\nargs: ${message.arguments}';
-  var nameAndArgs = "$withName$withArgs)";
+  var nameAndArgs = '$withName$withArgs)';
   newSource.write(originalSource.substring(0, closingParen));
   newSource.write(nameAndArgs);
   // We normally don't have anything after the closing paren, but

--- a/lib/src/message_rewriter.dart
+++ b/lib/src/message_rewriter.dart
@@ -14,7 +14,7 @@ import 'package:intl_translation/src/intl_message.dart';
 /// Return the modified source code. If there are errors parsing, list
 /// [sourceName] in the error message.
 String rewriteMessages(String source, String sourceName,
-    {useStringSubstitution = false}) {
+    {bool useStringSubstitution = false}) {
   var messages = findMessages(source, sourceName);
   messages.sort((a, b) => a.sourcePosition.compareTo(b.sourcePosition));
 
@@ -39,14 +39,14 @@ String rewriteMessages(String source, String sourceName,
 ///
 /// This may produce uglier source, but is more reliable.
 void rewriteRegenerating(
-    StringBuffer newSource, String source, int start, message) {
+    StringBuffer newSource, String source, int start, MainMessage message) {
   // TODO(alanknight): We could generate more efficient code than the
   // original here, dispatching more directly to the MessageLookup.
   newSource.write(message.toOriginalCode());
 }
 
 void rewriteWithStringSubstitution(
-    StringBuffer newSource, String source, int start, message) {
+    StringBuffer newSource, String source, int start, MainMessage message) {
   var originalSource =
       source.substring(message.sourcePosition, message.endPosition);
   var closingParen = originalSource.lastIndexOf(')');

--- a/lib/src/message_rewriter.dart
+++ b/lib/src/message_rewriter.dart
@@ -38,13 +38,14 @@ String rewriteMessages(String source, String sourceName,
 /// Rewrite the message by regenerating from our internal representation.
 ///
 /// This may produce uglier source, but is more reliable.
-rewriteRegenerating(StringBuffer newSource, String source, int start, message) {
+void rewriteRegenerating(
+    StringBuffer newSource, String source, int start, message) {
   // TODO(alanknight): We could generate more efficient code than the
   // original here, dispatching more directly to the MessageLookup.
   newSource.write(message.toOriginalCode());
 }
 
-rewriteWithStringSubstitution(
+void rewriteWithStringSubstitution(
     StringBuffer newSource, String source, int start, message) {
   var originalSource =
       source.substring(message.sourcePosition, message.endPosition);

--- a/lib/src/message_rewriter.dart
+++ b/lib/src/message_rewriter.dart
@@ -64,8 +64,8 @@ rewriteWithStringSubstitution(
   newSource.write(originalSource.substring(closingParen + 1));
 }
 
-final RegExp nameCheck = RegExp('[\\n,]\\s+name\:');
-final RegExp argsCheck = RegExp('[\\n,]\\s+args\:');
+final RegExp nameCheck = RegExp('[\\n,]\\s+name:');
+final RegExp argsCheck = RegExp('[\\n,]\\s+args:');
 
 /// Find all the messages in the [source] text.
 ///

--- a/lib/src/message_rewriter.dart
+++ b/lib/src/message_rewriter.dart
@@ -14,7 +14,7 @@ import 'package:intl_translation/src/intl_message.dart';
 /// Return the modified source code. If there are errors parsing, list
 /// [sourceName] in the error message.
 String rewriteMessages(String source, String sourceName,
-    {useStringSubstitution: false}) {
+    {useStringSubstitution = false}) {
   var messages = findMessages(source, sourceName);
   messages.sort((a, b) => a.sourcePosition.compareTo(b.sourcePosition));
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,13 +10,13 @@ environment:
   sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
-  analyzer: ^3.0.0
+  analyzer: ^4.0.0
   args: ^2.0.0
   dart_style: ^2.0.0
   intl: ^0.17.0
   path: ^1.0.0
-  petitparser: ^4.0.0
+  petitparser: ^5.0.0
 
 dev_dependencies:
-  lints: ^1.0.0
+  lints: '>=1.0.0 <3.0.0'
   test: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   dart_style: ^2.0.0
   intl: ^0.17.0
   path: ^1.0.0
-  petitparser: ^5.0.0
+  petitparser: '>=4.0.0 <6.0.0'
 
 dev_dependencies:
   lints: '>=1.0.0 <3.0.0'

--- a/test/data_directory.dart
+++ b/test/data_directory.dart
@@ -17,7 +17,7 @@ import "package:path/path.dart" as path;
 /// Returns whether [dir] is the root of the `intl` package. We validate that it
 /// is by looking for a pubspec file with the entry `name: intl`.
 bool _isIntlRoot(String dir) {
-  var file = new File(path.join(dir, 'pubspec.yaml'));
+  var file = File(path.join(dir, 'pubspec.yaml'));
   if (!file.existsSync()) return false;
   return file.readAsStringSync().contains('name: intl_translation\n');
 }
@@ -34,6 +34,6 @@ String get packageDirectory {
     if (_isIntlRoot(dir)) return dir;
     dir = path.dirname(dir);
   }
-  throw new UnsupportedError(
+  throw UnsupportedError(
       'Cannot find the root directory of the `intl_translation` package.');
 }

--- a/test/data_directory.dart
+++ b/test/data_directory.dart
@@ -12,6 +12,7 @@
 library data_directory;
 
 import 'dart:io';
+
 import 'package:path/path.dart' as path;
 
 /// Returns whether [dir] is the root of the `intl` package. We validate that it

--- a/test/data_directory.dart
+++ b/test/data_directory.dart
@@ -11,8 +11,8 @@
 ///   run things by default
 library data_directory;
 
-import "dart:io";
-import "package:path/path.dart" as path;
+import 'dart:io';
+import 'package:path/path.dart' as path;
 
 /// Returns whether [dir] is the root of the `intl` package. We validate that it
 /// is by looking for a pubspec file with the entry `name: intl`.

--- a/test/generate_localized/code_map_messages_all.dart
+++ b/test/generate_localized/code_map_messages_all.dart
@@ -21,12 +21,12 @@ String evaluateJsonTemplate(dynamic input, List<dynamic> args) {
   if (input == null) return null;
   if (input is String) return input;
   if (input is int) {
-    return "${args[input]}";
+    return '${args[input]}';
   }
 
   var template = input as List<dynamic>;
   var messageName = template.first;
-  if (messageName == "Intl.plural") {
+  if (messageName == 'Intl.plural') {
      var howMany = args[template[1] as int] as num;
      return evaluateJsonTemplate(
          Intl.pluralLogic(
@@ -39,7 +39,7 @@ String evaluateJsonTemplate(dynamic input, List<dynamic> args) {
              other: template[7]),
          args);
    }
-   if (messageName == "Intl.gender") {
+   if (messageName == 'Intl.gender') {
      var gender = args[template[1] as int] as String;
      return evaluateJsonTemplate(
          Intl.genderLogic(
@@ -49,7 +49,7 @@ String evaluateJsonTemplate(dynamic input, List<dynamic> args) {
              other: template[4]),
          args);
    }
-   if (messageName == "Intl.select") {
+   if (messageName == 'Intl.select') {
      var select = args[template[1] as int] as Object;
      var choices = template[2] as Map<Object, Object>;
      return evaluateJsonTemplate(Intl.selectLogic(select, choices), args);
@@ -57,12 +57,12 @@ String evaluateJsonTemplate(dynamic input, List<dynamic> args) {
 
    // If we get this far, then we are a basic interpolation, just strings and
    // ints.
-   var output = new StringBuffer();
+   var output = StringBuffer();
    for (var entry in template) {
      if (entry is int) {
-       output.write("${args[entry]}");
+       output.write('${args[entry]}');
      } else {
-       output.write("$entry");
+       output.write('$entry');
      }
    }
    return output.toString();

--- a/test/generate_localized/code_map_messages_all.dart
+++ b/test/generate_localized/code_map_messages_all.dart
@@ -3,8 +3,8 @@
 // delegating to the appropriate library.
 
 import 'package:intl/intl.dart';
-
-export 'code_map_messages_all_locales.dart' show initializeMessages;
+export 'code_map_messages_all_locales.dart'
+  show initializeMessages;
 
 /// Turn the JSON template into a string.
 ///
@@ -27,39 +27,45 @@ String evaluateJsonTemplate(dynamic input, List<dynamic> args) {
   var template = input as List<dynamic>;
   var messageName = template.first;
   if (messageName == 'Intl.plural') {
-    var howMany = args[template[1] as int] as num;
-    return evaluateJsonTemplate(
-        Intl.pluralLogic(howMany,
-            zero: template[2],
-            one: template[3],
-            two: template[4],
-            few: template[5],
-            many: template[6],
-            other: template[7]),
-        args);
-  }
-  if (messageName == 'Intl.gender') {
-    var gender = args[template[1] as int] as String;
-    return evaluateJsonTemplate(
-        Intl.genderLogic(gender,
-            female: template[2], male: template[3], other: template[4]),
-        args);
-  }
-  if (messageName == 'Intl.select') {
-    var select = args[template[1] as int] as Object;
-    var choices = template[2] as Map<Object, Object>;
-    return evaluateJsonTemplate(Intl.selectLogic(select, choices), args);
+     var howMany = args[template[1] as int] as num;
+     return evaluateJsonTemplate(
+         Intl.pluralLogic(
+             howMany,
+             zero: template[2],
+             one: template[3],
+             two: template[4],
+             few: template[5],
+             many: template[6],
+             other: template[7]),
+         args);
+   }
+   if (messageName == 'Intl.gender') {
+     var gender = args[template[1] as int] as String;
+     return evaluateJsonTemplate(
+         Intl.genderLogic(
+             gender,
+             female: template[2],
+             male: template[3],
+             other: template[4]),
+         args);
+   }
+   if (messageName == 'Intl.select') {
+     var select = args[template[1] as int] as Object;
+     var choices = template[2] as Map<Object, Object>;
+     return evaluateJsonTemplate(Intl.selectLogic(select, choices), args);
+   }
+
+   // If we get this far, then we are a basic interpolation, just strings and
+   // ints.
+   var output = StringBuffer();
+   for (var entry in template) {
+     if (entry is int) {
+       output.write('${args[entry]}');
+     } else {
+       output.write('$entry');
+     }
+   }
+   return output.toString();
   }
 
-  // If we get this far, then we are a basic interpolation, just strings and
-  // ints.
-  var output = StringBuffer();
-  for (var entry in template) {
-    if (entry is int) {
-      output.write('${args[entry]}');
-    } else {
-      output.write('$entry');
-    }
-  }
-  return output.toString();
-}
+ 

--- a/test/generate_localized/code_map_messages_all.dart
+++ b/test/generate_localized/code_map_messages_all.dart
@@ -3,8 +3,8 @@
 // delegating to the appropriate library.
 
 import 'package:intl/intl.dart';
-export 'code_map_messages_all_locales.dart'
-  show initializeMessages;
+
+export 'code_map_messages_all_locales.dart' show initializeMessages;
 
 /// Turn the JSON template into a string.
 ///
@@ -27,45 +27,39 @@ String evaluateJsonTemplate(dynamic input, List<dynamic> args) {
   var template = input as List<dynamic>;
   var messageName = template.first;
   if (messageName == 'Intl.plural') {
-     var howMany = args[template[1] as int] as num;
-     return evaluateJsonTemplate(
-         Intl.pluralLogic(
-             howMany,
-             zero: template[2],
-             one: template[3],
-             two: template[4],
-             few: template[5],
-             many: template[6],
-             other: template[7]),
-         args);
-   }
-   if (messageName == 'Intl.gender') {
-     var gender = args[template[1] as int] as String;
-     return evaluateJsonTemplate(
-         Intl.genderLogic(
-             gender,
-             female: template[2],
-             male: template[3],
-             other: template[4]),
-         args);
-   }
-   if (messageName == 'Intl.select') {
-     var select = args[template[1] as int] as Object;
-     var choices = template[2] as Map<Object, Object>;
-     return evaluateJsonTemplate(Intl.selectLogic(select, choices), args);
-   }
-
-   // If we get this far, then we are a basic interpolation, just strings and
-   // ints.
-   var output = StringBuffer();
-   for (var entry in template) {
-     if (entry is int) {
-       output.write('${args[entry]}');
-     } else {
-       output.write('$entry');
-     }
-   }
-   return output.toString();
+    var howMany = args[template[1] as int] as num;
+    return evaluateJsonTemplate(
+        Intl.pluralLogic(howMany,
+            zero: template[2],
+            one: template[3],
+            two: template[4],
+            few: template[5],
+            many: template[6],
+            other: template[7]),
+        args);
+  }
+  if (messageName == 'Intl.gender') {
+    var gender = args[template[1] as int] as String;
+    return evaluateJsonTemplate(
+        Intl.genderLogic(gender,
+            female: template[2], male: template[3], other: template[4]),
+        args);
+  }
+  if (messageName == 'Intl.select') {
+    var select = args[template[1] as int] as Object;
+    var choices = template[2] as Map<Object, Object>;
+    return evaluateJsonTemplate(Intl.selectLogic(select, choices), args);
   }
 
- 
+  // If we get this far, then we are a basic interpolation, just strings and
+  // ints.
+  var output = StringBuffer();
+  for (var entry in template) {
+    if (entry is int) {
+      output.write('${args[entry]}');
+    } else {
+      output.write('$entry');
+    }
+  }
+  return output.toString();
+}

--- a/test/generate_localized/code_map_messages_all_locales.dart
+++ b/test/generate_localized/code_map_messages_all_locales.dart
@@ -2,14 +2,20 @@
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
 
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:implementation_imports, file_names, unnecessary_new
+// ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
+// ignore_for_file:argument_type_not_assignable, invalid_assignment
+// ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
+// ignore_for_file:comment_references
+
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 import 'package:intl/src/intl_helpers.dart';
 
 import 'code_map_messages_fr.dart' deferred as messages_fr;
 
-typedef LibraryLoader = Future<dynamic> Function();
-
+typedef Future<dynamic> LibraryLoader();
 Map<String, LibraryLoader> _deferredLibraries = {
   'fr': messages_fr.loadLibrary,
 };
@@ -26,16 +32,17 @@ MessageLookupByLibrary _findExact(String localeName) {
 /// User programs should call this before using [localeName] for messages.
 Future<bool> initializeMessages(String localeName) async {
   var availableLocale = Intl.verifiedLocale(
-      localeName, (locale) => _deferredLibraries[locale] != null,
-      onFailure: (_) => null);
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null);
   if (availableLocale == null) {
-    return Future.value(false);
+    return new Future.value(false);
   }
   var lib = _deferredLibraries[availableLocale];
-  await (lib == null ? Future.value(false) : lib());
-  initializeInternalMessageLookup(() => CompositeMessageLookup());
+  await (lib == null ? new Future.value(false) : lib());
+  initializeInternalMessageLookup(() => new CompositeMessageLookup());
   messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
-  return Future.value(true);
+  return new Future.value(true);
 }
 
 bool _messagesExistFor(String locale) {
@@ -47,8 +54,8 @@ bool _messagesExistFor(String locale) {
 }
 
 MessageLookupByLibrary _findGeneratedMessagesFor(String locale) {
-  var actualLocale =
-      Intl.verifiedLocale(locale, _messagesExistFor, onFailure: (_) => null);
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
+      onFailure: (_) => null);
   if (actualLocale == null) return null;
   return _findExact(actualLocale);
 }

--- a/test/generate_localized/code_map_messages_all_locales.dart
+++ b/test/generate_localized/code_map_messages_all_locales.dart
@@ -2,20 +2,14 @@
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
 
-// Ignore issues from commonly used lints in this file.
-// ignore_for_file:implementation_imports, file_names, unnecessary_new
-// ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
-// ignore_for_file:argument_type_not_assignable, invalid_assignment
-// ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
-// ignore_for_file:comment_references
-
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 import 'package:intl/src/intl_helpers.dart';
 
 import 'code_map_messages_fr.dart' deferred as messages_fr;
 
-typedef Future<dynamic> LibraryLoader();
+typedef LibraryLoader = Future<dynamic> Function();
+
 Map<String, LibraryLoader> _deferredLibraries = {
   'fr': messages_fr.loadLibrary,
 };
@@ -32,17 +26,16 @@ MessageLookupByLibrary _findExact(String localeName) {
 /// User programs should call this before using [localeName] for messages.
 Future<bool> initializeMessages(String localeName) async {
   var availableLocale = Intl.verifiedLocale(
-    localeName,
-    (locale) => _deferredLibraries[locale] != null,
-    onFailure: (_) => null);
+      localeName, (locale) => _deferredLibraries[locale] != null,
+      onFailure: (_) => null);
   if (availableLocale == null) {
-    return new Future.value(false);
+    return Future.value(false);
   }
   var lib = _deferredLibraries[availableLocale];
-  await (lib == null ? new Future.value(false) : lib());
-  initializeInternalMessageLookup(() => new CompositeMessageLookup());
+  await (lib == null ? Future.value(false) : lib());
+  initializeInternalMessageLookup(() => CompositeMessageLookup());
   messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
-  return new Future.value(true);
+  return Future.value(true);
 }
 
 bool _messagesExistFor(String locale) {
@@ -54,8 +47,8 @@ bool _messagesExistFor(String locale) {
 }
 
 MessageLookupByLibrary _findGeneratedMessagesFor(String locale) {
-  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
-      onFailure: (_) => null);
+  var actualLocale =
+      Intl.verifiedLocale(locale, _messagesExistFor, onFailure: (_) => null);
   if (actualLocale == null) return null;
   return _findExact(actualLocale);
 }

--- a/test/generate_localized/code_map_messages_fr.dart
+++ b/test/generate_localized/code_map_messages_fr.dart
@@ -18,7 +18,8 @@ import 'dart:collection';
 
 final messages = new MessageLookup();
 
-typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+typedef String MessageIfAbsent(
+    String messageStr, List<Object> args);
 
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'fr';

--- a/test/generate_localized/code_map_messages_fr.dart
+++ b/test/generate_localized/code_map_messages_fr.dart
@@ -3,27 +3,32 @@
 // messages from the main program should be duplicated here with the same
 // function name.
 
-import 'package:intl/message_lookup_by_library.dart';
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
 
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+import 'dart:convert';
 import 'code_map_messages_all.dart' show evaluateJsonTemplate;
 
-final messages = MessageLookup();
+import 'dart:collection';
 
-typedef MessageIfAbsent = String Function(String messageStr, List<Object> args);
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<Object> args);
 
 class MessageLookup extends MessageLookupByLibrary {
-  @override
   String get localeName => 'fr';
 
-  @override
-  // ignore: type_annotate_public_apis
-  String evaluateMessage(translation, List<dynamic> args) {
+  String evaluateMessage(Object translation, List<dynamic> args) {
     return evaluateJsonTemplate(translation, args);
   }
 
-  @override
   Map<String, dynamic> get messages => _constMessages;
   static const _constMessages = <String, Object>{
-    'Hello from application': "Bonjour de l'application"
+    "Hello from application": "Bonjour de l'application"
   };
 }

--- a/test/generate_localized/code_map_messages_fr.dart
+++ b/test/generate_localized/code_map_messages_fr.dart
@@ -3,31 +3,27 @@
 // messages from the main program should be duplicated here with the same
 // function name.
 
-// Ignore issues from commonly used lints in this file.
-// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
-// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
-// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
-// ignore_for_file:unused_import, file_names
-
-import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
-import 'dart:convert';
+
 import 'code_map_messages_all.dart' show evaluateJsonTemplate;
 
-import 'dart:collection';
+final messages = MessageLookup();
 
-final messages = new MessageLookup();
-
-typedef String MessageIfAbsent(
-    String messageStr, List<Object> args);
+typedef MessageIfAbsent = String Function(String messageStr, List<Object> args);
 
 class MessageLookup extends MessageLookupByLibrary {
+  @override
   String get localeName => 'fr';
 
+  @override
+  // ignore: type_annotate_public_apis
   String evaluateMessage(translation, List<dynamic> args) {
     return evaluateJsonTemplate(translation, args);
   }
-  Map<String, dynamic> get messages => _constMessages;
-  static const _constMessages = <String, Object>{"Hello from application":"Bonjour de l'application"};
 
+  @override
+  Map<String, dynamic> get messages => _constMessages;
+  static const _constMessages = <String, Object>{
+    'Hello from application': "Bonjour de l'application"
+  };
 }

--- a/test/generate_localized/code_map_test.dart
+++ b/test/generate_localized/code_map_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 import 'code_map_messages_all.dart';
 
-appMessage() => Intl.message('Hello from application', desc: 'hi');
+String appMessage() => Intl.message('Hello from application', desc: 'hi');
 
 main() async {
   Intl.defaultLocale = 'fr';

--- a/test/generate_localized/code_map_test.dart
+++ b/test/generate_localized/code_map_test.dart
@@ -11,7 +11,7 @@ import 'code_map_messages_all.dart';
 
 String appMessage() => Intl.message('Hello from application', desc: 'hi');
 
-main() async {
+void main() async {
   Intl.defaultLocale = 'fr';
   await initializeMessages('fr');
   test('String lookups should provide translation to French', () {

--- a/test/generate_localized/code_map_test.dart
+++ b/test/generate_localized/code_map_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// An application using the code map messages.
-
 import 'package:intl/intl.dart';
 import 'package:test/test.dart';
 

--- a/test/generate_localized/regenerate.sh
+++ b/test/generate_localized/regenerate.sh
@@ -2,4 +2,5 @@
 # Regenerate the messages Dart files.
 dart ../../bin/generate_from_arb.dart \
   --code-map --generated-file-prefix=code_map_ \
-  code_map_test.dart app_translation_getfromthelocale.arb
+  code_map_test.dart app_translation_getfromthelocale.arb \
+  --no-null-safety

--- a/test/intl_message_test.dart
+++ b/test/intl_message_test.dart
@@ -6,44 +6,44 @@ import 'package:intl_translation/src/intl_message.dart';
 import 'package:test/test.dart';
 
 main() {
-  test("Prefer explicit =0 to ZERO in plural", () {
+  test('Prefer explicit =0 to ZERO in plural', () {
     var msg = Plural.from(
-        "main",
+        'main',
         [
-          ["=0", "explicit"],
-          ["ZERO", "general"]
+          ['=0', 'explicit'],
+          ['ZERO', 'general']
         ],
         null);
-    expect((msg["zero"] as LiteralString).string, "explicit");
+    expect((msg['zero'] as LiteralString).string, 'explicit');
   });
-  test("Prefer explicit =1 to ONE in plural", () {
+  test('Prefer explicit =1 to ONE in plural', () {
     var msg = Plural.from(
-        "main",
+        'main',
         [
-          ["=1", "explicit"],
-          ["ONE", "general"]
+          ['=1', 'explicit'],
+          ['ONE', 'general']
         ],
         null);
-    expect((msg["one"] as LiteralString).string, "explicit");
+    expect((msg['one'] as LiteralString).string, 'explicit');
   });
-  test("Prefer explicit =1 to ONE in plural, reverse order", () {
+  test('Prefer explicit =1 to ONE in plural, reverse order', () {
     var msg = Plural.from(
-        "main",
+        'main',
         [
-          ["ONE", "general"],
-          ["=1", "explicit"]
+          ['ONE', 'general'],
+          ['=1', 'explicit']
         ],
         null);
-    expect((msg["one"] as LiteralString).string, "explicit");
+    expect((msg['one'] as LiteralString).string, 'explicit');
   });
-  test("Prefer explicit =2 to TWO in plural", () {
+  test('Prefer explicit =2 to TWO in plural', () {
     var msg = Plural.from(
-        "main",
+        'main',
         [
-          ["=2", "explicit"],
-          ["TWO", "general"]
+          ['=2', 'explicit'],
+          ['TWO', 'general']
         ],
         null);
-    expect((msg["two"] as LiteralString).string, "explicit");
+    expect((msg['two'] as LiteralString).string, 'explicit');
   });
 }

--- a/test/intl_message_test.dart
+++ b/test/intl_message_test.dart
@@ -5,7 +5,7 @@
 import 'package:intl_translation/src/intl_message.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   test('Prefer explicit =0 to ZERO in plural', () {
     var msg = Plural.from(
         'main',
@@ -16,6 +16,7 @@ main() {
         null);
     expect((msg['zero'] as LiteralString).string, 'explicit');
   });
+
   test('Prefer explicit =1 to ONE in plural', () {
     var msg = Plural.from(
         'main',
@@ -26,6 +27,7 @@ main() {
         null);
     expect((msg['one'] as LiteralString).string, 'explicit');
   });
+
   test('Prefer explicit =1 to ONE in plural, reverse order', () {
     var msg = Plural.from(
         'main',
@@ -36,6 +38,7 @@ main() {
         null);
     expect((msg['one'] as LiteralString).string, 'explicit');
   });
+
   test('Prefer explicit =2 to TWO in plural', () {
     var msg = Plural.from(
         'main',

--- a/test/intl_message_test.dart
+++ b/test/intl_message_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 
 main() {
   test("Prefer explicit =0 to ZERO in plural", () {
-    var msg = new Plural.from(
+    var msg = Plural.from(
         "main",
         [
           ["=0", "explicit"],
@@ -17,7 +17,7 @@ main() {
     expect((msg["zero"] as LiteralString).string, "explicit");
   });
   test("Prefer explicit =1 to ONE in plural", () {
-    var msg = new Plural.from(
+    var msg = Plural.from(
         "main",
         [
           ["=1", "explicit"],
@@ -27,7 +27,7 @@ main() {
     expect((msg["one"] as LiteralString).string, "explicit");
   });
   test("Prefer explicit =1 to ONE in plural, reverse order", () {
-    var msg = new Plural.from(
+    var msg = Plural.from(
         "main",
         [
           ["ONE", "general"],
@@ -37,7 +37,7 @@ main() {
     expect((msg["one"] as LiteralString).string, "explicit");
   });
   test("Prefer explicit =2 to TWO in plural", () {
-    var msg = new Plural.from(
+    var msg = Plural.from(
         "main",
         [
           ["=2", "explicit"],

--- a/test/message_extraction/debug.sh
+++ b/test/message_extraction/debug.sh
@@ -11,6 +11,8 @@ dart ../../bin/extract_to_arb.dart sample_with_messages.dart \
 
 dart make_hardcoded_translation.dart intl_messages.arb
 
-dart ../../bin/generate_from_arb.dart --json --generated-file-prefix=foo_ \
+dart ../../bin/generate_from_arb.dart \
+  --json --generated-file-prefix=foo_ \
+  --no-null-safety \
   sample_with_messages.dart part_of_sample_with_messages.dart \
   translation_fr.arb french2.arb translation_de_DE.arb

--- a/test/message_extraction/debug.sh
+++ b/test/message_extraction/debug.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 # The message_extraction_test.dart test uses a temporary directory and spawns
 # separate processes for each step. This can make it very painful to debug the
 # steps.
@@ -6,8 +7,10 @@
 # directory. You can run the script to run the test locally, or use this to
 # run individual steps or create them as launches in the editor.
 dart ../../bin/extract_to_arb.dart sample_with_messages.dart \
-part_of_sample_with_messages.dart
+  part_of_sample_with_messages.dart
+
 dart make_hardcoded_translation.dart intl_messages.arb
+
 dart ../../bin/generate_from_arb.dart --json --generated-file-prefix=foo_ \
-sample_with_messages.dart part_of_sample_with_messages.dart \
-translation_fr.arb french2.arb translation_de_DE.arb
+  sample_with_messages.dart part_of_sample_with_messages.dart \
+  translation_fr.arb french2.arb translation_de_DE.arb

--- a/test/message_extraction/embedded_plural_text_after.dart
+++ b/test/message_extraction/embedded_plural_text_after.dart
@@ -8,6 +8,8 @@ library embedded_plural_text_after;
 
 import "package:intl/intl.dart";
 
-embeddedPlural2(n) => Intl.message(
+String embeddedPlural2(n) => Intl.message(
     "${Intl.plural(n, zero: 'none', one: 'one', other: 'some')} plus text.",
-    name: 'embeddedPlural2', desc: 'An embedded plural', args: [n]);
+    name: 'embeddedPlural2',
+    desc: 'An embedded plural',
+    args: [n]);

--- a/test/message_extraction/embedded_plural_text_after.dart
+++ b/test/message_extraction/embedded_plural_text_after.dart
@@ -6,7 +6,7 @@
 /// following the plural expression.
 library embedded_plural_text_after;
 
-import "package:intl/intl.dart";
+import 'package:intl/intl.dart';
 
 String embeddedPlural2(n) => Intl.message(
     "${Intl.plural(n, zero: 'none', one: 'one', other: 'some')} plus text.",

--- a/test/message_extraction/embedded_plural_text_after.dart
+++ b/test/message_extraction/embedded_plural_text_after.dart
@@ -8,7 +8,7 @@ library embedded_plural_text_after;
 
 import 'package:intl/intl.dart';
 
-String embeddedPlural2(n) => Intl.message(
+String embeddedPlural2(num n) => Intl.message(
     "${Intl.plural(n, zero: 'none', one: 'one', other: 'some')} plus text.",
     name: 'embeddedPlural2',
     desc: 'An embedded plural',

--- a/test/message_extraction/embedded_plural_text_after_test.dart
+++ b/test/message_extraction/embedded_plural_text_after_test.dart
@@ -4,12 +4,12 @@
 
 library embedded_plural_text_after_test;
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
-import "failed_extraction_test.dart";
+import 'failed_extraction_test.dart';
 
 main() {
-  test("Expect failure because of embedded plural with text after it", () {
+  test('Expect failure because of embedded plural with text after it', () {
     List<String> specialFiles = ['embedded_plural_text_after.dart'];
     runTestWithWarnings(
         warningsAreErrors: true,

--- a/test/message_extraction/embedded_plural_text_after_test.dart
+++ b/test/message_extraction/embedded_plural_text_after_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(const Duration(seconds: 180))
-
 library embedded_plural_text_after_test;
 
 import "package:test/test.dart";

--- a/test/message_extraction/embedded_plural_text_after_test.dart
+++ b/test/message_extraction/embedded_plural_text_after_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(seconds: 180))
+
 library embedded_plural_text_after_test;
 
 import 'package:test/test.dart';

--- a/test/message_extraction/embedded_plural_text_after_test.dart
+++ b/test/message_extraction/embedded_plural_text_after_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 import 'failed_extraction_test.dart';
 
-main() {
+void main() {
   test('Expect failure because of embedded plural with text after it', () {
     List<String> specialFiles = ['embedded_plural_text_after.dart'];
     runTestWithWarnings(

--- a/test/message_extraction/embedded_plural_text_before.dart
+++ b/test/message_extraction/embedded_plural_text_before.dart
@@ -6,7 +6,7 @@
 /// before the plural expression.
 library embedded_plural_text_before;
 
-import "package:intl/intl.dart";
+import 'package:intl/intl.dart';
 
 String embeddedPlural(n) => Intl.message(
     "There are ${Intl.plural(n, zero: 'nothing', one: 'one', other: 'some')}.",

--- a/test/message_extraction/embedded_plural_text_before.dart
+++ b/test/message_extraction/embedded_plural_text_before.dart
@@ -8,6 +8,8 @@ library embedded_plural_text_before;
 
 import "package:intl/intl.dart";
 
-embeddedPlural(n) => Intl.message(
+String embeddedPlural(n) => Intl.message(
     "There are ${Intl.plural(n, zero: 'nothing', one: 'one', other: 'some')}.",
-    name: 'embeddedPlural', desc: 'An embedded plural', args: [n]);
+    name: 'embeddedPlural',
+    desc: 'An embedded plural',
+    args: [n]);

--- a/test/message_extraction/embedded_plural_text_before.dart
+++ b/test/message_extraction/embedded_plural_text_before.dart
@@ -8,7 +8,7 @@ library embedded_plural_text_before;
 
 import 'package:intl/intl.dart';
 
-String embeddedPlural(n) => Intl.message(
+String embeddedPlural(num n) => Intl.message(
     "There are ${Intl.plural(n, zero: 'nothing', one: 'one', other: 'some')}.",
     name: 'embeddedPlural',
     desc: 'An embedded plural',

--- a/test/message_extraction/embedded_plural_text_before_test.dart
+++ b/test/message_extraction/embedded_plural_text_before_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(seconds: 180))
+
 library embedded_plural_text_before_test;
 
 import 'package:test/test.dart';

--- a/test/message_extraction/embedded_plural_text_before_test.dart
+++ b/test/message_extraction/embedded_plural_text_before_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(const Duration(seconds: 180))
-
 library embedded_plural_text_before_test;
 
 import "package:test/test.dart";

--- a/test/message_extraction/embedded_plural_text_before_test.dart
+++ b/test/message_extraction/embedded_plural_text_before_test.dart
@@ -4,12 +4,12 @@
 
 library embedded_plural_text_before_test;
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
-import "failed_extraction_test.dart";
+import 'failed_extraction_test.dart';
 
 main() {
-  test("Expect failure because of embedded plural with text before it", () {
+  test('Expect failure because of embedded plural with text before it', () {
     List<String> files = ['embedded_plural_text_before.dart'];
     runTestWithWarnings(
         warningsAreErrors: true,

--- a/test/message_extraction/embedded_plural_text_before_test.dart
+++ b/test/message_extraction/embedded_plural_text_before_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 import 'failed_extraction_test.dart';
 
-main() {
+void main() {
   test('Expect failure because of embedded plural with text before it', () {
     List<String> files = ['embedded_plural_text_before.dart'];
     runTestWithWarnings(

--- a/test/message_extraction/examples_parsing_test.dart
+++ b/test/message_extraction/examples_parsing_test.dart
@@ -4,7 +4,6 @@
 
 /// Test for parsing the examples argument from an Intl.message call. Very
 /// minimal so far.
-
 import 'dart:io';
 
 import 'package:intl_translation/extract_messages.dart';

--- a/test/message_extraction/examples_parsing_test.dart
+++ b/test/message_extraction/examples_parsing_test.dart
@@ -14,11 +14,11 @@ import 'package:test/test.dart';
 import '../data_directory.dart';
 
 main() {
-  test("Message examples are correctly extracted", () {
+  test('Message examples are correctly extracted', () {
     var file = path.join(packageDirectory, 'test', 'message_extraction',
         'sample_with_messages.dart');
     var extraction = MessageExtraction();
     var messages = extraction.parseFile(File(file));
-    expect(messages['message2'].examples, {"x": 3});
+    expect(messages['message2'].examples, {'x': 3});
   });
 }

--- a/test/message_extraction/examples_parsing_test.dart
+++ b/test/message_extraction/examples_parsing_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(const Duration(seconds: 180))
-
 /// Test for parsing the examples argument from an Intl.message call. Very
 /// minimal so far.
 

--- a/test/message_extraction/examples_parsing_test.dart
+++ b/test/message_extraction/examples_parsing_test.dart
@@ -13,7 +13,7 @@ import 'package:test/test.dart';
 
 import '../data_directory.dart';
 
-main() {
+void main() {
   test('Message examples are correctly extracted', () {
     var file = path.join(packageDirectory, 'test', 'message_extraction',
         'sample_with_messages.dart');

--- a/test/message_extraction/examples_parsing_test.dart
+++ b/test/message_extraction/examples_parsing_test.dart
@@ -2,8 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(seconds: 180))
+
 /// Test for parsing the examples argument from an Intl.message call. Very
 /// minimal so far.
+
 import 'dart:io';
 
 import 'package:intl_translation/extract_messages.dart';

--- a/test/message_extraction/examples_parsing_test.dart
+++ b/test/message_extraction/examples_parsing_test.dart
@@ -17,8 +17,8 @@ main() {
   test("Message examples are correctly extracted", () {
     var file = path.join(packageDirectory, 'test', 'message_extraction',
         'sample_with_messages.dart');
-    var extraction = new MessageExtraction();
-    var messages = extraction.parseFile(new File(file));
+    var extraction = MessageExtraction();
+    var messages = extraction.parseFile(File(file));
     expect(messages['message2'].examples, {"x": 3});
   });
 }

--- a/test/message_extraction/failed_extraction_test.dart
+++ b/test/message_extraction/failed_extraction_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 
 import 'message_extraction_test.dart';
 
-main() {
+void main() {
   test('Expect warnings but successful extraction', () {
     runTestWithWarnings(warningsAreErrors: false, expectedExitCode: 0);
   });
@@ -26,7 +26,7 @@ void runTestWithWarnings(
     int expectedExitCode,
     bool embeddedPlurals = true,
     List<String> sourceFiles = defaultFiles}) {
-  verify(ProcessResult result) {
+  void verify(ProcessResult result) {
     try {
       expect(result.exitCode, expectedExitCode);
     } finally {
@@ -44,9 +44,7 @@ void runTestWithWarnings(
     args.add('--no-embedded-plurals');
   }
   var files = sourceFiles.map(asTempDirPath).toList();
-  List<String> allArgs = [program, ...args, ...files]
-    
-    ;
+  List<String> allArgs = [program, ...args, ...files];
   var callback = expectAsync1(verify);
 
   run(null, allArgs).then(callback);

--- a/test/message_extraction/failed_extraction_test.dart
+++ b/test/message_extraction/failed_extraction_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(const Duration(seconds: 180))
-
 library failed_extraction_test;
 
 import "dart:io";

--- a/test/message_extraction/failed_extraction_test.dart
+++ b/test/message_extraction/failed_extraction_test.dart
@@ -16,7 +16,7 @@ main() {
   });
 }
 
-const List<String> defaultFiles = const [
+const List<String> defaultFiles = [
   "sample_with_messages.dart",
   "part_of_sample_with_messages.dart"
 ];
@@ -24,8 +24,8 @@ const List<String> defaultFiles = const [
 void runTestWithWarnings(
     {bool warningsAreErrors,
     int expectedExitCode,
-    bool embeddedPlurals: true,
-    List<String> sourceFiles: defaultFiles}) {
+    bool embeddedPlurals = true,
+    List<String> sourceFiles = defaultFiles}) {
   verify(ProcessResult result) {
     try {
       expect(result.exitCode, expectedExitCode);
@@ -44,9 +44,9 @@ void runTestWithWarnings(
     args.add('--no-embedded-plurals');
   }
   var files = sourceFiles.map(asTempDirPath).toList();
-  List<String> allArgs = [program]
-    ..addAll(args)
-    ..addAll(files);
+  List<String> allArgs = [program, ...args, ...files]
+    
+    ;
   var callback = expectAsync1(verify);
 
   run(null, allArgs).then(callback);

--- a/test/message_extraction/failed_extraction_test.dart
+++ b/test/message_extraction/failed_extraction_test.dart
@@ -21,11 +21,12 @@ const List<String> defaultFiles = [
   'part_of_sample_with_messages.dart'
 ];
 
-void runTestWithWarnings(
-    {bool warningsAreErrors,
-    int expectedExitCode,
-    bool embeddedPlurals = true,
-    List<String> sourceFiles = defaultFiles}) {
+void runTestWithWarnings({
+  bool warningsAreErrors,
+  int expectedExitCode,
+  bool embeddedPlurals = true,
+  List<String> sourceFiles = defaultFiles,
+}) {
   void verify(ProcessResult result) {
     try {
       expect(result.exitCode, expectedExitCode);
@@ -35,7 +36,7 @@ void runTestWithWarnings(
   }
 
   copyFilesToTempDirectory();
-  var program = asTestDirPath('../../bin/extract_to_arb.dart');
+  var program = 'bin/extract_to_arb.dart';
   List<String> args = ['--output-dir=$tempDir'];
   if (warningsAreErrors) {
     args.add('--warnings-are-errors');
@@ -43,11 +44,13 @@ void runTestWithWarnings(
   if (!embeddedPlurals) {
     args.add('--no-embedded-plurals');
   }
-  var files = sourceFiles.map(asTempDirPath).toList();
-  List<String> allArgs = [program, ...args, ...files];
+  List<String> allArgs = [
+    ...args,
+    ...sourceFiles,
+  ];
   var callback = expectAsync1(verify);
 
-  run(null, allArgs).then(callback);
+  run(program, allArgs).then(callback);
 }
 
 typedef ThenArgument = dynamic Function(ProcessResult _);

--- a/test/message_extraction/failed_extraction_test.dart
+++ b/test/message_extraction/failed_extraction_test.dart
@@ -4,21 +4,21 @@
 
 library failed_extraction_test;
 
-import "dart:io";
+import 'dart:io';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
-import "message_extraction_test.dart";
+import 'message_extraction_test.dart';
 
 main() {
-  test("Expect warnings but successful extraction", () {
+  test('Expect warnings but successful extraction', () {
     runTestWithWarnings(warningsAreErrors: false, expectedExitCode: 0);
   });
 }
 
 const List<String> defaultFiles = [
-  "sample_with_messages.dart",
-  "part_of_sample_with_messages.dart"
+  'sample_with_messages.dart',
+  'part_of_sample_with_messages.dart'
 ];
 
 void runTestWithWarnings(
@@ -35,8 +35,8 @@ void runTestWithWarnings(
   }
 
   copyFilesToTempDirectory();
-  var program = asTestDirPath("../../bin/extract_to_arb.dart");
-  List<String> args = ["--output-dir=$tempDir"];
+  var program = asTestDirPath('../../bin/extract_to_arb.dart');
+  List<String> args = ['--output-dir=$tempDir'];
   if (warningsAreErrors) {
     args.add('--warnings-are-errors');
   }

--- a/test/message_extraction/find_messages_test.dart
+++ b/test/message_extraction/find_messages_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(const Duration(seconds: 180))
-
 import 'package:intl_translation/extract_messages.dart';
 import 'package:intl_translation/src/message_rewriter.dart';
 import 'package:test/test.dart';

--- a/test/message_extraction/find_messages_test.dart
+++ b/test/message_extraction/find_messages_test.dart
@@ -6,7 +6,7 @@ import 'package:intl_translation/extract_messages.dart';
 import 'package:intl_translation/src/message_rewriter.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('findMessages denied usages', () {
     test('fails with message on non-literal examples Map', () {
       final messageExtraction = MessageExtraction();

--- a/test/message_extraction/find_messages_test.dart
+++ b/test/message_extraction/find_messages_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(seconds: 180))
+
 import 'package:intl_translation/extract_messages.dart';
 import 'package:intl_translation/src/message_rewriter.dart';
 import 'package:test/test.dart';

--- a/test/message_extraction/find_messages_test.dart
+++ b/test/message_extraction/find_messages_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 main() {
   group('findMessages denied usages', () {
     test('fails with message on non-literal examples Map', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       findMessages('''
 final variable = 'foo';
 
@@ -23,7 +23,7 @@ String message(String string) =>
     });
 
     test('fails with message on prefixed expression in interpolation', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       findMessages(
           'String message(object) => Intl.message("\${object.property}");',
           '',
@@ -39,7 +39,7 @@ String message(String string) =>
 
     test('fails on call with name referencing variable name inside a function',
         () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       findMessages('''
       class MessageTest {
         String functionName() {
@@ -56,7 +56,7 @@ String message(String string) =>
     });
 
     test('fails on referencing a name from listed fields declaration', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       findMessages('''
       class MessageTest {
         String first, second = Intl.message('message string',
@@ -73,7 +73,7 @@ String message(String string) =>
 
   group('findMessages accepted usages', () {
     test('succeeds on Intl call from class getter', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       var messages = findMessages('''
       class MessageTest {
         String get messageName => Intl.message("message string",
@@ -85,7 +85,7 @@ String message(String string) =>
     });
 
     test('succeeds on Intl call in top variable declaration', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       var messages = findMessages(
           'List<String> list = [Intl.message("message string", '
               'name: "list", desc: "in list")];',
@@ -97,7 +97,7 @@ String message(String string) =>
     });
 
     test('succeeds on Intl call in member variable declaration', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       var messages = findMessages('''
       class MessageTest {
         final String messageName = Intl.message("message string",
@@ -111,7 +111,7 @@ String message(String string) =>
 
     // Note: this type of usage is not recommended.
     test('succeeds on Intl call inside a function as variable declaration', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       var messages = findMessages('''
       class MessageTest {
         String functionName() {
@@ -125,7 +125,7 @@ String message(String string) =>
     });
 
     test('succeeds on list field declaration', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       var messages = findMessages('''
       class MessageTest {
         String first, second = Intl.message('message string', desc: 'test');
@@ -137,7 +137,7 @@ String message(String string) =>
     });
 
     test('succeeds on prefixed Intl call', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       final messages = findMessages('''
       class MessageTest {
         static final String prefixedMessage =
@@ -152,7 +152,7 @@ String message(String string) =>
 
   group('messages with the same name', () {
     test('are resolved in favour of the earlier one by default', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       final messages = findMessages('''
       final msg1 = Intl.message('hello there', desc: 'abc');
       final msg2 = Intl.message('hello there', desc: 'def');
@@ -162,7 +162,7 @@ String message(String string) =>
     });
 
     test('are resolved with custom merger', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       messageExtraction.mergeMessages =
           (m1, m2) => m1..description = '${m1.description}/${m2.description}';
       final messages = findMessages('''
@@ -176,7 +176,7 @@ String message(String string) =>
 
   group('documentation', () {
     test('is populated from dartdoc', () {
-      final messageExtraction = new MessageExtraction();
+      final messageExtraction = MessageExtraction();
       final messages = findMessages('''
       class MessageTest {
         /// Dartdoc.

--- a/test/message_extraction/foo_messages_all.dart
+++ b/test/message_extraction/foo_messages_all.dart
@@ -5,5 +5,5 @@
 library keep_the_static_analysis_from_complaining;
 
 initializeMessages(_) => throw UnimplementedError(
-    "This entire file is only here to make the static"
-    " analysis happy. It will be generated during actual tests.");
+    'This entire file is only here to make the static'
+    ' analysis happy. It will be generated during actual tests.');

--- a/test/message_extraction/foo_messages_all.dart
+++ b/test/message_extraction/foo_messages_all.dart
@@ -4,6 +4,6 @@
 
 library keep_the_static_analysis_from_complaining;
 
-initializeMessages(_) => throw new UnimplementedError(
+initializeMessages(_) => throw UnimplementedError(
     "This entire file is only here to make the static"
     " analysis happy. It will be generated during actual tests.");

--- a/test/message_extraction/foo_messages_all.dart
+++ b/test/message_extraction/foo_messages_all.dart
@@ -4,6 +4,6 @@
 
 library keep_the_static_analysis_from_complaining;
 
-Future<bool> initializeMessages(String _) =>
+Future<bool> initializeMessages(_) =>
     throw UnimplementedError('This entire file is only here to make the static'
         ' analysis happy. It will be generated during actual tests.');

--- a/test/message_extraction/foo_messages_all.dart
+++ b/test/message_extraction/foo_messages_all.dart
@@ -4,6 +4,6 @@
 
 library keep_the_static_analysis_from_complaining;
 
-initializeMessages(_) => throw UnimplementedError(
-    'This entire file is only here to make the static'
-    ' analysis happy. It will be generated during actual tests.');
+Future<bool> initializeMessages(String _) =>
+    throw UnimplementedError('This entire file is only here to make the static'
+        ' analysis happy. It will be generated during actual tests.');

--- a/test/message_extraction/make_hardcoded_translation.dart
+++ b/test/message_extraction/make_hardcoded_translation.dart
@@ -16,139 +16,139 @@ import 'package:path/path.dart' as path;
 
 /// A list of the French translations that we will produce.
 var french = {
-  "types": r"{a}, {b}, {c}",
-  "This string extends across multiple lines.":
-      "Cette message prend plusiers lignes.",
-  "message2": r"Un autre message avec un seul paramètre {x}",
-  "alwaysTranslated": "Cette chaîne est toujours traduit",
-  "message1": "Il s'agit d'un message",
-  "\"So-called\"": "\"Soi-disant\"",
-  "trickyInterpolation": r"L'interpolation est délicate "
-      r"quand elle se termine une phrase comme {s}.",
-  "message3": "Caractères qui doivent être échapper, par exemple barres \\ "
-      "dollars \${ (les accolades sont ok), et xml/html réservés <& et "
-      "des citations \" "
-      "avec quelques paramètres ainsi {a}, {b}, et {c}",
-  "notAlwaysTranslated": "Ce manque certaines traductions",
-  "thisNameIsNotInTheOriginal": "Could this lead to something malicious?",
-  "Ancient Greek hangman characters: 𐅆𐅇.":
-      "Anciens caractères grecs jeux du pendu: 𐅆𐅇.",
-  "escapable": "Escapes: \n\r\f\b\t\v.",
-  "sameContentsDifferentName": "Bonjour tout le monde",
-  "differentNameSameContents": "Bonjour tout le monde",
-  "rentToBePaid": "loyer",
-  "rentAsVerb": "louer",
-  "plurals": "{num,plural, =0{Est-ce que nulle est pluriel?}=1{C'est singulier}"
+  'types': r'{a}, {b}, {c}',
+  'This string extends across multiple lines.':
+      'Cette message prend plusiers lignes.',
+  'message2': r'Un autre message avec un seul paramètre {x}',
+  'alwaysTranslated': 'Cette chaîne est toujours traduit',
+  'message1': "Il s'agit d'un message",
+  '\"So-called\"': '\"Soi-disant\"',
+  'trickyInterpolation': r"L'interpolation est délicate "
+      r'quand elle se termine une phrase comme {s}.',
+  'message3': 'Caractères qui doivent être échapper, par exemple barres \\ '
+      'dollars \${ (les accolades sont ok), et xml/html réservés <& et '
+      'des citations \" '
+      'avec quelques paramètres ainsi {a}, {b}, et {c}',
+  'notAlwaysTranslated': 'Ce manque certaines traductions',
+  'thisNameIsNotInTheOriginal': 'Could this lead to something malicious?',
+  'Ancient Greek hangman characters: 𐅆𐅇.':
+      'Anciens caractères grecs jeux du pendu: 𐅆𐅇.',
+  'escapable': 'Escapes: \n\r\f\b\t\v.',
+  'sameContentsDifferentName': 'Bonjour tout le monde',
+  'differentNameSameContents': 'Bonjour tout le monde',
+  'rentToBePaid': 'loyer',
+  'rentAsVerb': 'louer',
+  'plurals': "{num,plural, =0{Est-ce que nulle est pluriel?}=1{C'est singulier}"
       "other{C'est pluriel ({num}).}}",
-  "whereTheyWentMessage": "{gender,select, male{{name} est allé à sa {place}}"
-      "female{{name} est allée à sa {place}}other{{name}"
-      " est allé à sa {place}}}",
+  'whereTheyWentMessage': '{gender,select, male{{name} est allé à sa {place}}'
+      'female{{name} est allée à sa {place}}other{{name}'
+      ' est allé à sa {place}}}',
   // Gratuitously different translation for testing. Ignoring gender of place.
-  "nestedMessage": "{combinedGender,select, "
-      "other{"
-      "{number,plural, "
+  'nestedMessage': '{combinedGender,select, '
+      'other{'
+      '{number,plural, '
       "=0{Personne n'avait allé à la {place}}"
-      "=1{{names} était allé à la {place}}"
-      "other{{names} étaient allés à la {place}}"
-      "}"
-      "}"
-      "female{"
-      "{number,plural, "
-      "=1{{names} était allée à la {place}}"
-      "other{{names} étaient allées à la {place}}"
-      "}"
-      "}"
-      "}",
-  "outerPlural": "{n,plural, =0{rien}=1{un}other{quelques-uns}}",
-  "outerGender": "{g,select, male {homme} female {femme} other {autre}}",
-  "pluralThatFailsParsing": "{noOfThings,plural, "
-      "=1{1 chose:}other{{noOfThings} choses:}}",
-  "nestedOuter": "{number,plural, other{"
-      "{gen,select, male{{number} homme}other{{number} autre}}}}",
-  "outerSelect": "{currency,select, CDN{{amount} dollars Canadiens}"
-      "other{{amount} certaine devise ou autre.}}}",
-  "nestedSelect": "{currency,select, CDN{{amount,plural, "
-      "=1{{amount} dollar Canadien}"
-      "other{{amount} dollars Canadiens}}}"
+      '=1{{names} était allé à la {place}}'
+      'other{{names} étaient allés à la {place}}'
+      '}'
+      '}'
+      'female{'
+      '{number,plural, '
+      '=1{{names} était allée à la {place}}'
+      'other{{names} étaient allées à la {place}}'
+      '}'
+      '}'
+      '}',
+  'outerPlural': '{n,plural, =0{rien}=1{un}other{quelques-uns}}',
+  'outerGender': '{g,select, male {homme} female {femme} other {autre}}',
+  'pluralThatFailsParsing': '{noOfThings,plural, '
+      '=1{1 chose:}other{{noOfThings} choses:}}',
+  'nestedOuter': '{number,plural, other{'
+      '{gen,select, male{{number} homme}other{{number} autre}}}}',
+  'outerSelect': '{currency,select, CDN{{amount} dollars Canadiens}'
+      'other{{amount} certaine devise ou autre.}}}',
+  'nestedSelect': '{currency,select, CDN{{amount,plural, '
+      '=1{{amount} dollar Canadien}'
+      'other{{amount} dollars Canadiens}}}'
       "other{N'importe quoi}"
-      "}}",
-  "literalDollar": "Cinq sous est US\$0.05",
+      '}}',
+  'literalDollar': 'Cinq sous est US\$0.05',
   r"'<>{}= +-_$()&^%$#@!~`'": r"interessant (fr): '<>{}= +-_$()&^%$#@!~`'",
-  "extractable": "Ce message devrait être extractible",
-  "skipMessageExistingTranslation": "Ce message devrait ignorer la traduction"
+  'extractable': 'Ce message devrait être extractible',
+  'skipMessageExistingTranslation': 'Ce message devrait ignorer la traduction'
 };
 
 // Used to test having translations in multiple files.
 var frenchExtra = {
-  "YouveGotMessages_method": "Cela vient d'une méthode",
-  "nonLambda": "Cette méthode n'est pas un lambda",
-  "staticMessage": "Cela vient d'une méthode statique",
+  'YouveGotMessages_method': "Cela vient d'une méthode",
+  'nonLambda': "Cette méthode n'est pas un lambda",
+  'staticMessage': "Cela vient d'une méthode statique",
 };
 
 /// A list of the German translations that we will produce.
 var german = {
-  "types": r"{a}, {b}, {c}",
-  "This string extends across multiple lines.":
-      "Dieser String erstreckt sich über mehrere Zeilen erstrecken.",
-  "message2": r"Eine weitere Meldung mit dem Parameter {x}",
-  "alwaysTranslated": "Diese Zeichenkette wird immer übersetzt",
-  "message1": "Dies ist eine Nachricht",
-  "\"So-called\"": "\"Sogenannt\"",
-  "trickyInterpolation": r"Interpolation ist schwierig, wenn es einen Satz "
-      "wie dieser endet {s}.",
-  "message3": "Zeichen, die Flucht benötigen, zB Schrägstriche \\ Dollar "
-      "\${ (geschweiften Klammern sind ok) und xml reservierte Zeichen <& und "
-      "Zitate \" Parameter {a}, {b} und {c}",
-  "YouveGotMessages_method": "Dies ergibt sich aus einer Methode",
-  "nonLambda": "Diese Methode ist nicht eine Lambda",
-  "staticMessage": "Dies ergibt sich aus einer statischen Methode",
-  "thisNameIsNotInTheOriginal": "Could this lead to something malicious?",
-  "Ancient Greek hangman characters: 𐅆𐅇.":
-      "Antike griechische Galgenmännchen Zeichen: 𐅆𐅇",
-  "escapable": "Escapes: \n\r\f\b\t\v.",
-  "sameContentsDifferentName": "Hallo Welt",
-  "differentNameSameContents": "Hallo Welt",
-  "rentToBePaid": "Miete",
-  "rentAsVerb": "mieten",
-  "plurals": "{num,plural, =0{Ist Null Plural?}=1{Dies ist einmalig}"
-      "other{Dies ist Plural ({num}).}}",
-  "whereTheyWentMessage": "{gender,select, male{{name} ging zu seinem {place}}"
-      "female{{name} ging zu ihrem {place}}other{{name} ging zu seinem {place}}}",
+  'types': r'{a}, {b}, {c}',
+  'This string extends across multiple lines.':
+      'Dieser String erstreckt sich über mehrere Zeilen erstrecken.',
+  'message2': r'Eine weitere Meldung mit dem Parameter {x}',
+  'alwaysTranslated': 'Diese Zeichenkette wird immer übersetzt',
+  'message1': 'Dies ist eine Nachricht',
+  '\"So-called\"': '\"Sogenannt\"',
+  'trickyInterpolation': r'Interpolation ist schwierig, wenn es einen Satz '
+      'wie dieser endet {s}.',
+  'message3': 'Zeichen, die Flucht benötigen, zB Schrägstriche \\ Dollar '
+      '\${ (geschweiften Klammern sind ok) und xml reservierte Zeichen <& und '
+      'Zitate \" Parameter {a}, {b} und {c}',
+  'YouveGotMessages_method': 'Dies ergibt sich aus einer Methode',
+  'nonLambda': 'Diese Methode ist nicht eine Lambda',
+  'staticMessage': 'Dies ergibt sich aus einer statischen Methode',
+  'thisNameIsNotInTheOriginal': 'Could this lead to something malicious?',
+  'Ancient Greek hangman characters: 𐅆𐅇.':
+      'Antike griechische Galgenmännchen Zeichen: 𐅆𐅇',
+  'escapable': 'Escapes: \n\r\f\b\t\v.',
+  'sameContentsDifferentName': 'Hallo Welt',
+  'differentNameSameContents': 'Hallo Welt',
+  'rentToBePaid': 'Miete',
+  'rentAsVerb': 'mieten',
+  'plurals': '{num,plural, =0{Ist Null Plural?}=1{Dies ist einmalig}'
+      'other{Dies ist Plural ({num}).}}',
+  'whereTheyWentMessage': '{gender,select, male{{name} ging zu seinem {place}}'
+      'female{{name} ging zu ihrem {place}}other{{name} ging zu seinem {place}}}',
   //Note that we're only using the gender of the people. The gender of the
   //place also matters, but we're not dealing with that here.
-  "nestedMessage": "{combinedGender,select, "
-      "other{"
-      "{number,plural, "
-      "=0{Niemand ging zu {place}}"
-      "=1{{names} ging zum {place}}"
-      "other{{names} gingen zum {place}}"
-      "}"
-      "}"
-      "female{"
-      "{number,plural, "
-      "=1{{names} ging in dem {place}}"
-      "other{{names} gingen zum {place}}"
-      "}"
-      "}"
-      "}",
-  "outerPlural": "{n,plural, =0{Null}=1{ein}other{einige}}",
-  "outerGender": "{g,select, male{Mann}female{Frau}other{andere}}",
-  "pluralThatFailsParsing": "{noOfThings,plural, "
-      "=1{eins:}other{{noOfThings} Dinge:}}",
-  "nestedOuter": "{number,plural, other{"
-      "{gen,select, male{{number} Mann}other{{number} andere}}}}",
-  "outerSelect": "{currency,select, CDN{{amount} Kanadischen dollar}"
-      "other{{amount} einige Währung oder anderen.}}}",
-  "nestedSelect": "{currency,select, CDN{{amount,plural, "
-      "=1{{amount} Kanadischer dollar}"
-      "other{{amount} Kanadischen dollar}}}"
-      "other{whatever}"
-      "}",
-  "literalDollar": "Fünf Cent US \$ 0.05",
+  'nestedMessage': '{combinedGender,select, '
+      'other{'
+      '{number,plural, '
+      '=0{Niemand ging zu {place}}'
+      '=1{{names} ging zum {place}}'
+      'other{{names} gingen zum {place}}'
+      '}'
+      '}'
+      'female{'
+      '{number,plural, '
+      '=1{{names} ging in dem {place}}'
+      'other{{names} gingen zum {place}}'
+      '}'
+      '}'
+      '}',
+  'outerPlural': '{n,plural, =0{Null}=1{ein}other{einige}}',
+  'outerGender': '{g,select, male{Mann}female{Frau}other{andere}}',
+  'pluralThatFailsParsing': '{noOfThings,plural, '
+      '=1{eins:}other{{noOfThings} Dinge:}}',
+  'nestedOuter': '{number,plural, other{'
+      '{gen,select, male{{number} Mann}other{{number} andere}}}}',
+  'outerSelect': '{currency,select, CDN{{amount} Kanadischen dollar}'
+      'other{{amount} einige Währung oder anderen.}}}',
+  'nestedSelect': '{currency,select, CDN{{amount,plural, '
+      '=1{{amount} Kanadischer dollar}'
+      'other{{amount} Kanadischen dollar}}}'
+      'other{whatever}'
+      '}',
+  'literalDollar': 'Fünf Cent US \$ 0.05',
   r"'<>{}= +-_$()&^%$#@!~`'": r"interessant (de): '<>{}= +-_$()&^%$#@!~`'",
-  "extractable": "Diese Nachricht sollte extrahierbar sein",
-  "skipMessageExistingTranslation":
-      "Diese Nachricht sollte die Übersetzung überspringen"
+  'extractable': 'Diese Nachricht sollte extrahierbar sein',
+  'skipMessageExistingTranslation':
+      'Diese Nachricht sollte die Übersetzung überspringen'
 };
 
 /// The output directory for translated files.
@@ -160,7 +160,7 @@ const jsonCodec = JsonCodec();
 /// up the translations in [translations].
 void translate(Map originals, String locale, Map translations,
     [String filename]) {
-  var translated = {"_locale": locale};
+  var translated = {'_locale': locale};
   originals.forEach((name, text) {
     if (translations[name] != null) {
       translated[name] = translations[name];
@@ -178,14 +178,14 @@ main(List<String> args) {
     exit(0);
   }
   var parser = ArgParser();
-  parser.addOption("output-dir",
+  parser.addOption('output-dir',
       defaultsTo: '.', callback: (value) => targetDir = value);
   parser.parse(args);
 
   var fileArgs = args.where((x) => x.contains('.arb'));
 
   var messages = jsonCodec.decode(File(fileArgs.first).readAsStringSync());
-  translate(messages, "fr", french);
-  translate(messages, "fr", frenchExtra, 'french2.arb');
-  translate(messages, "de_DE", german);
+  translate(messages, 'fr', french);
+  translate(messages, 'fr', frenchExtra, 'french2.arb');
+  translate(messages, 'de_DE', german);
 }

--- a/test/message_extraction/make_hardcoded_translation.dart
+++ b/test/message_extraction/make_hardcoded_translation.dart
@@ -15,7 +15,7 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 
 /// A list of the French translations that we will produce.
-var french = {
+Map<String, String> french = {
   'types': r'{a}, {b}, {c}',
   'This string extends across multiple lines.':
       'Cette message prend plusiers lignes.',
@@ -79,14 +79,14 @@ var french = {
 };
 
 // Used to test having translations in multiple files.
-var frenchExtra = {
+Map<String, String> frenchExtra = {
   'YouveGotMessages_method': "Cela vient d'une méthode",
   'nonLambda': "Cette méthode n'est pas un lambda",
   'staticMessage': "Cela vient d'une méthode statique",
 };
 
 /// A list of the German translations that we will produce.
-var german = {
+Map<String, String> german = {
   'types': r'{a}, {b}, {c}',
   'This string extends across multiple lines.':
       'Dieser String erstreckt sich über mehrere Zeilen erstrecken.',

--- a/test/message_extraction/make_hardcoded_translation.dart
+++ b/test/message_extraction/make_hardcoded_translation.dart
@@ -154,7 +154,7 @@ var german = {
 /// The output directory for translated files.
 String targetDir;
 
-const jsonCodec = const JsonCodec();
+const jsonCodec = JsonCodec();
 
 /// Generate a translated json version from [originals] in [locale] looking
 /// up the translations in [translations].
@@ -167,7 +167,7 @@ void translate(Map originals, String locale, Map translations,
     }
   });
   var file =
-      new File(path.join(targetDir, filename ?? 'translation_$locale.arb'));
+      File(path.join(targetDir, filename ?? 'translation_$locale.arb'));
   file.writeAsStringSync(jsonCodec.encode(translated));
 }
 
@@ -177,14 +177,14 @@ main(List<String> args) {
         '[originalFile.arb]');
     exit(0);
   }
-  var parser = new ArgParser();
+  var parser = ArgParser();
   parser.addOption("output-dir",
       defaultsTo: '.', callback: (value) => targetDir = value);
   parser.parse(args);
 
   var fileArgs = args.where((x) => x.contains('.arb'));
 
-  var messages = jsonCodec.decode(new File(fileArgs.first).readAsStringSync());
+  var messages = jsonCodec.decode(File(fileArgs.first).readAsStringSync());
   translate(messages, "fr", french);
   translate(messages, "fr", frenchExtra, 'french2.arb');
   translate(messages, "de_DE", german);

--- a/test/message_extraction/make_hardcoded_translation.dart
+++ b/test/message_extraction/make_hardcoded_translation.dart
@@ -22,12 +22,12 @@ var french = {
   'message2': r'Un autre message avec un seul paramètre {x}',
   'alwaysTranslated': 'Cette chaîne est toujours traduit',
   'message1': "Il s'agit d'un message",
-  '\"So-called\"': '\"Soi-disant\"',
+  '"So-called"': '"Soi-disant"',
   'trickyInterpolation': r"L'interpolation est délicate "
       r'quand elle se termine une phrase comme {s}.',
   'message3': 'Caractères qui doivent être échapper, par exemple barres \\ '
       'dollars \${ (les accolades sont ok), et xml/html réservés <& et '
-      'des citations \" '
+      'des citations " '
       'avec quelques paramètres ainsi {a}, {b}, et {c}',
   'notAlwaysTranslated': 'Ce manque certaines traductions',
   'thisNameIsNotInTheOriginal': 'Could this lead to something malicious?',
@@ -93,12 +93,12 @@ var german = {
   'message2': r'Eine weitere Meldung mit dem Parameter {x}',
   'alwaysTranslated': 'Diese Zeichenkette wird immer übersetzt',
   'message1': 'Dies ist eine Nachricht',
-  '\"So-called\"': '\"Sogenannt\"',
+  '"So-called"': '"Sogenannt"',
   'trickyInterpolation': r'Interpolation ist schwierig, wenn es einen Satz '
       'wie dieser endet {s}.',
   'message3': 'Zeichen, die Flucht benötigen, zB Schrägstriche \\ Dollar '
       '\${ (geschweiften Klammern sind ok) und xml reservierte Zeichen <& und '
-      'Zitate \" Parameter {a}, {b} und {c}',
+      'Zitate " Parameter {a}, {b} und {c}',
   'YouveGotMessages_method': 'Dies ergibt sich aus einer Methode',
   'nonLambda': 'Diese Methode ist nicht eine Lambda',
   'staticMessage': 'Dies ergibt sich aus einer statischen Methode',

--- a/test/message_extraction/make_hardcoded_translation.dart
+++ b/test/message_extraction/make_hardcoded_translation.dart
@@ -166,12 +166,11 @@ void translate(Map originals, String locale, Map translations,
       translated[name] = translations[name];
     }
   });
-  var file =
-      File(path.join(targetDir, filename ?? 'translation_$locale.arb'));
+  var file = File(path.join(targetDir, filename ?? 'translation_$locale.arb'));
   file.writeAsStringSync(jsonCodec.encode(translated));
 }
 
-main(List<String> args) {
+void main(List<String> args) {
   if (args.isEmpty) {
     print('Usage: make_hardcoded_translation [--output-dir=<dir>] '
         '[originalFile.arb]');

--- a/test/message_extraction/make_hardcoded_translation.dart
+++ b/test/message_extraction/make_hardcoded_translation.dart
@@ -7,7 +7,6 @@
 /// extract_message.dart for the files sample_with_messages.dart and
 /// part_of_sample_with_messages.dart and writing out hard-coded translations
 /// for German and French locales.
-
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/message_extraction/make_hardcoded_translation.dart
+++ b/test/message_extraction/make_hardcoded_translation.dart
@@ -7,6 +7,7 @@
 /// extract_message.dart for the files sample_with_messages.dart and
 /// part_of_sample_with_messages.dart and writing out hard-coded translations
 /// for German and French locales.
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/message_extraction/message_extraction_flutter_test.dart
+++ b/test/message_extraction/message_extraction_flutter_test.dart
@@ -2,8 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(seconds: 180))
+
 /// A test for message extraction and code generation using generated
 /// JSON rather than functions
+
+import 'package:test/test.dart';
+
 import 'message_extraction_test.dart' as main_test;
 
 void main() {

--- a/test/message_extraction/message_extraction_flutter_test.dart
+++ b/test/message_extraction/message_extraction_flutter_test.dart
@@ -6,7 +6,7 @@
 /// JSON rather than functions
 import 'message_extraction_test.dart' as main_test;
 
-main() {
+void main() {
   main_test.useJson = true;
   main_test.useFlutterLocaleSplit = true;
   main_test.main();

--- a/test/message_extraction/message_extraction_flutter_test.dart
+++ b/test/message_extraction/message_extraction_flutter_test.dart
@@ -2,13 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(const Duration(seconds: 180))
-
 /// A test for message extraction and code generation using generated
 /// JSON rather than functions
-
-import 'package:test/test.dart';
-
 import 'message_extraction_test.dart' as main_test;
 
 main() {

--- a/test/message_extraction/message_extraction_json_test.dart
+++ b/test/message_extraction/message_extraction_json_test.dart
@@ -2,8 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(seconds: 180))
+
 /// A test for message extraction and code generation using generated
 /// JSON rather than functions
+
+import 'package:test/test.dart';
+
 import 'message_extraction_test.dart' as main_test;
 
 void main() {

--- a/test/message_extraction/message_extraction_json_test.dart
+++ b/test/message_extraction/message_extraction_json_test.dart
@@ -2,13 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(const Duration(seconds: 180))
-
 /// A test for message extraction and code generation using generated
 /// JSON rather than functions
-
-import 'package:test/test.dart';
-
 import 'message_extraction_test.dart' as main_test;
 
 main() {

--- a/test/message_extraction/message_extraction_json_test.dart
+++ b/test/message_extraction/message_extraction_json_test.dart
@@ -6,7 +6,7 @@
 /// JSON rather than functions
 import 'message_extraction_test.dart' as main_test;
 
-main() {
+void main() {
   main_test.useJson = true;
   main_test.main();
 }

--- a/test/message_extraction/message_extraction_no_deferred_test.dart
+++ b/test/message_extraction/message_extraction_no_deferred_test.dart
@@ -2,9 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(seconds: 180))
+
 /// A test for message extraction and code generation not using deferred
 /// loading for the generated code.
 library message_extraction_no_deferred_test;
+
+import 'package:test/test.dart';
 
 import 'message_extraction_test.dart' as main_test;
 

--- a/test/message_extraction/message_extraction_no_deferred_test.dart
+++ b/test/message_extraction/message_extraction_no_deferred_test.dart
@@ -2,13 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(const Duration(seconds: 180))
-
 /// A test for message extraction and code generation not using deferred
 /// loading for the generated code.
 library message_extraction_no_deferred_test;
-
-import 'package:test/test.dart';
 
 import 'message_extraction_test.dart' as mainTest;
 

--- a/test/message_extraction/message_extraction_no_deferred_test.dart
+++ b/test/message_extraction/message_extraction_no_deferred_test.dart
@@ -8,7 +8,7 @@ library message_extraction_no_deferred_test;
 
 import 'message_extraction_test.dart' as main_test;
 
-main() {
+void main() {
   main_test.useDeferredLoading = false;
   main_test.main();
 }

--- a/test/message_extraction/message_extraction_no_deferred_test.dart
+++ b/test/message_extraction/message_extraction_no_deferred_test.dart
@@ -6,9 +6,9 @@
 /// loading for the generated code.
 library message_extraction_no_deferred_test;
 
-import 'message_extraction_test.dart' as mainTest;
+import 'message_extraction_test.dart' as main_test;
 
 main() {
-  mainTest.useDeferredLoading = false;
-  mainTest.main();
+  main_test.useDeferredLoading = false;
+  main_test.main();
 }

--- a/test/message_extraction/message_extraction_test.dart
+++ b/test/message_extraction/message_extraction_test.dart
@@ -2,12 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(seconds: 180))
+
 library message_extraction_test;
 
+import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
+
+import '../data_directory.dart';
 
 /// Should we use deferred loading.
 bool useDeferredLoading = true;
@@ -24,6 +30,9 @@ String get _deferredLoadPrefix => useDeferredLoading ? '' : 'no-';
 
 String get deferredLoadArg => '--${_deferredLoadPrefix}use-deferred-loading';
 
+/// The VM arguments we were given, most important package-root.
+final vmArgs = Platform.executableArguments;
+
 /// For testing we move the files into a temporary directory so as not to leave
 /// generated files around after a failed test. For debugging, we omit that
 /// step if [useLocalDirectory] is true. The place we move them to is saved as
@@ -36,125 +45,157 @@ String _createTempDir() => useLocalDirectory
 
 bool useLocalDirectory = false;
 
+/// Translate a relative file path into this test directory. This is
+/// applied to all the arguments of [run]. It will ignore a string that
+/// is an absolute path or begins with "--", because some of the arguments
+/// might be command-line options.
+String asTestDirPath([String s]) {
+  if (s == null || s.startsWith('--') || path.isAbsolute(s)) return s;
+  return path.join(packageDirectory, 'test', 'message_extraction', s);
+}
+
+/// Translate a relative file path into our temp directory. This is
+/// applied to all the arguments of [run]. It will ignore a string that
+/// is an absolute path or begins with "--", because some of the arguments
+/// might be command-line options.
+String asTempDirPath([String s]) {
+  if (s == null || s.startsWith('--') || path.isAbsolute(s)) return s;
+  return path.join(tempDir, s);
+}
+
+typedef ThenResult = Future<ProcessResult> Function(ProcessResult _);
+
 void main() {
   setUp(copyFilesToTempDirectory);
   tearDown(deleteGeneratedFiles);
 
   test(
       'Test round trip message extraction, translation, code generation, '
-      'and printing', () async {
-    var result = await extractMessages();
-    _checkResult('extractMessages', result);
-
-    result = await generateTranslationFiles();
-    _checkResult('generateTranslationFiles', result);
-
-    result = await generateCodeFromTranslation();
-    _checkResult('generateCodeFromTranslation', result);
-
-    result = await runAndVerify();
-    _checkResult('runAndVerify', result);
+      'and printing', () {
+    var makeSureWeVerify = expectAsync1(runAndVerify);
+    return extractMessages(null)
+        .then((result) {
+          return generateTranslationFiles(result);
+        })
+        .then((result) {
+          return generateCodeFromTranslation(result);
+        })
+        .then(makeSureWeVerify)
+        .then(checkResult);
   });
 }
 
-void copyFilesToTempDirectory() {
+Future<void> copyFilesToTempDirectory() async {
   if (useLocalDirectory) {
     return;
   }
 
   var files = [
-    'arb_list.txt',
-    'dart_list.txt',
-    'embedded_plural_text_after.dart',
-    'embedded_plural_text_before.dart',
-    'mock_flutter/services.dart',
-    'part_of_sample_with_messages.dart',
-    'print_to_list.dart',
-    'sample_with_messages.dart',
+    asTestDirPath('sample_with_messages.dart'),
+    asTestDirPath('part_of_sample_with_messages.dart'),
+    asTestDirPath('verify_messages.dart'),
+    asTestDirPath('run_and_verify.dart'),
+    asTestDirPath('embedded_plural_text_before.dart'),
+    asTestDirPath('embedded_plural_text_after.dart'),
+    asTestDirPath('print_to_list.dart'),
+    asTestDirPath('dart_list.txt'),
+    asTestDirPath('arb_list.txt'),
+    asTestDirPath('mock_flutter/services.dart'),
   ];
 
-  for (var name in files) {
-    var file = File(path.join('test', 'message_extraction', name));
+  for (var filePath in files) {
+    var file = File(filePath);
     if (file.existsSync()) {
-      // TODO: does this handle 'mock_flutter/services.dart' correctly?
-      file.copySync(path.join(tempDir, path.basename(name)));
+      file.copySync(path.join(tempDir, path.basename(filePath)));
     }
   }
+
+  // Here we copy the package config file so the test can locate packages.
+  var configFile = File.fromUri(await Isolate.packageConfig);
+  var destFile = File(path.join(tempDir, '.dart_tool', 'package_config.json'));
+  if (!destFile.parent.existsSync()) {
+    destFile.parent.createSync();
+  }
+  configFile.copySync(destFile.path);
 }
 
 void deleteGeneratedFiles() {
   if (useLocalDirectory) return;
-
   try {
     Directory(tempDir).deleteSync(recursive: true);
   } on Error catch (e) {
-    print('Failed to delete $tempDir: $e');
+    print('Failed to delete $tempDir');
+    print('Exception:\n$e');
   }
 }
 
-/// Run the Dart script with the given set of args.
-Future<ProcessResult> run(String script, List<String> args) {
-  // Inject '--output-dir' in between the script and its arguments.
-  return Process.run(
-    Platform.executable,
-    [
-      path.absolute(script),
-      '--output-dir=$tempDir',
-      ...args,
-    ],
-    workingDirectory: tempDir,
-  );
+/// Run the process with the given list of filenames, which we assume
+/// are in dir() and need to be qualified in case that's not our working
+/// directory.
+Future<ProcessResult> run(
+    ProcessResult previousResult, List<String> filenames) {
+  // If there's a failure in one of the sub-programs, print its output.
+  checkResult(previousResult);
+  var filesInTheRightDirectory = filenames
+      .map((x) => asTempDirPath(x))
+      .map((x) => path.normalize(x))
+      .toList();
+  // Inject the script argument --output-dir in between the script and its
+  // arguments.
+  List<String> args = [
+    ...vmArgs,
+    filesInTheRightDirectory.first,
+    '--output-dir=$tempDir',
+    ...filesInTheRightDirectory.skip(1)
+  ];
+  var result = Process.run(Platform.executable, args,
+      stdoutEncoding: Utf8Codec(), stderrEncoding: Utf8Codec());
+  return result;
 }
 
-void _checkResult(String stepName, ProcessResult result) {
-  expect(
-    result.exitCode,
-    0,
-    reason:
-        'step: $stepName\nstdout: ${result.stdout}\nstderr: ${result.stderr}',
-  );
+void checkResult(ProcessResult result) {
+  if (result != null) {
+    if (result.exitCode != 0) {
+      print('Error running sub-program:');
+      print(result.stdout);
+      print(result.stderr);
+      print('exitCode=${result.exitCode}');
+    }
+
+    expect(result.exitCode, 0);
+  }
 }
 
-Future<ProcessResult> extractMessages() {
-  return run(
-    'bin/extract_to_arb.dart',
-    [
+Future<ProcessResult> extractMessages(ProcessResult previousResult) =>
+    run(previousResult, [
+      asTestDirPath('../../bin/extract_to_arb.dart'),
       '--suppress-warnings',
-      '--sources-list-file=dart_list.txt',
-    ],
-  );
-}
+      '--sources-list-file',
+      'dart_list.txt'
+    ]);
 
-Future<ProcessResult> generateTranslationFiles() {
-  return run(
-    'test/message_extraction/make_hardcoded_translation.dart',
-    [
-      'intl_messages.arb',
-    ],
-  );
-}
+Future<ProcessResult> generateTranslationFiles(ProcessResult previousResult) =>
+    run(previousResult, [
+      asTestDirPath('make_hardcoded_translation.dart'),
+      'intl_messages.arb'
+    ]);
 
-Future<ProcessResult> generateCodeFromTranslation() {
-  return run(
-    'bin/generate_from_arb.dart',
-    [
+Future<ProcessResult> generateCodeFromTranslation(
+        ProcessResult previousResult) =>
+    run(previousResult, [
+      asTestDirPath('../../bin/generate_from_arb.dart'),
       deferredLoadArg,
-      '--' + (useJson ? '' : 'no-') + 'json',
-      '--' + (useFlutterLocaleSplit ? '' : 'no-') + 'flutter',
+      '--${useJson ? '' : 'no-'}json',
+      '--${useFlutterLocaleSplit ? '' : 'no-'}flutter',
       '--flutter-import-path=.', // Mocks package:flutter/services.dart
       '--generated-file-prefix=foo_',
-      '--sources-list-file=dart_list.txt',
-      '--translations-list-file=arb_list.txt',
+      '--sources-list-file',
+      'dart_list.txt',
+      '--translations-list-file',
+      'arb_list.txt',
       '--no-null-safety',
-    ],
-  );
-}
+    ]);
 
-Future<ProcessResult> runAndVerify() {
-  return run(
-    'test/message_extraction/run_and_verify.dart',
-    [
-      'intl_messages.arb',
-    ],
-  );
+Future<ProcessResult> runAndVerify(ProcessResult previousResult) {
+  return run(previousResult, ['run_and_verify.dart', 'intl_messages.arb']);
 }

--- a/test/message_extraction/message_extraction_test.dart
+++ b/test/message_extraction/message_extraction_test.dart
@@ -36,7 +36,7 @@ final vmArgs = Platform.executableArguments;
 /// generated files around after a failed test. For debugging, we omit that
 /// step if [useLocalDirectory] is true. The place we move them to is saved as
 /// [tempDir].
-String get tempDir => _tempDir == null ? _tempDir = _createTempDir() : _tempDir;
+String get tempDir => _tempDir ?? (_tempDir = _createTempDir());
 String _tempDir;
 String _createTempDir() => useLocalDirectory
     ? '.'
@@ -102,7 +102,7 @@ void copyFilesToTempDirectory() {
   ];
 
   for (var filename in files) {
-    var file = new File(filename);
+    var file = File(filename);
     if (file.existsSync()) {
       file.copySync(path.join(tempDir, path.basename(filename)));
     }
@@ -122,7 +122,7 @@ void copyFilesToTempDirectory() {
 void deleteGeneratedFiles() {
   if (useLocalDirectory) return;
   try {
-    new Directory(tempDir).deleteSync(recursive: true);
+    Directory(tempDir).deleteSync(recursive: true);
   } on Error catch (e) {
     print("Failed to delete $tempDir");
     print("Exception:\n$e");
@@ -142,13 +142,13 @@ Future<ProcessResult> run(
       .toList();
   // Inject the script argument --output-dir in between the script and its
   // arguments.
-  List<String> args = []
-    ..addAll(vmArgs)
-    ..add(filesInTheRightDirectory.first)
-    ..addAll(["--output-dir=$tempDir"])
-    ..addAll(filesInTheRightDirectory.skip(1));
+  List<String> args = [...vmArgs, filesInTheRightDirectory.first, "--output-dir=$tempDir", ...filesInTheRightDirectory.skip(1)]
+    
+    
+    
+    ;
   var result = Process.run(dart, args,
-      stdoutEncoding: new Utf8Codec(), stderrEncoding: new Utf8Codec());
+      stdoutEncoding: Utf8Codec(), stderrEncoding: Utf8Codec());
   return result;
 }
 

--- a/test/message_extraction/message_extraction_test.dart
+++ b/test/message_extraction/message_extraction_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(const Duration(seconds: 180))
-
 library message_extraction_test;
 
 import 'dart:convert';
@@ -193,7 +191,8 @@ Future<ProcessResult> generateCodeFromTranslation(
       '--sources-list-file',
       'dart_list.txt',
       '--translations-list-file',
-      'arb_list.txt'
+      'arb_list.txt',
+      '--no-null-safety',
     ]);
 
 Future<ProcessResult> runAndVerify(ProcessResult previousResult) {

--- a/test/message_extraction/message_extraction_test.dart
+++ b/test/message_extraction/message_extraction_test.dart
@@ -49,7 +49,7 @@ var useLocalDirectory = false;
 /// is an absolute path or begins with "--", because some of the arguments
 /// might be command-line options.
 String asTestDirPath([String s]) {
-  if (s == null || s.startsWith("--") || path.isAbsolute(s)) return s;
+  if (s == null || s.startsWith('--') || path.isAbsolute(s)) return s;
   return path.join(packageDirectory, 'test', 'message_extraction', s);
 }
 
@@ -58,7 +58,7 @@ String asTestDirPath([String s]) {
 /// is an absolute path or begins with "--", because some of the arguments
 /// might be command-line options.
 String asTempDirPath([String s]) {
-  if (s == null || s.startsWith("--") || path.isAbsolute(s)) return s;
+  if (s == null || s.startsWith('--') || path.isAbsolute(s)) return s;
   return path.join(tempDir, s);
 }
 
@@ -68,8 +68,8 @@ void main() {
   setUp(copyFilesToTempDirectory);
   tearDown(deleteGeneratedFiles);
   test(
-      "Test round trip message extraction, translation, code generation, "
-      "and printing", () {
+      'Test round trip message extraction, translation, code generation, '
+      'and printing', () {
     var makeSureWeVerify = expectAsync1(runAndVerify);
     return extractMessages(null)
         .then((result) {
@@ -124,8 +124,8 @@ void deleteGeneratedFiles() {
   try {
     Directory(tempDir).deleteSync(recursive: true);
   } on Error catch (e) {
-    print("Failed to delete $tempDir");
-    print("Exception:\n$e");
+    print('Failed to delete $tempDir');
+    print('Exception:\n$e');
   }
 }
 
@@ -145,7 +145,7 @@ Future<ProcessResult> run(
   List<String> args = [
     ...vmArgs,
     filesInTheRightDirectory.first,
-    "--output-dir=$tempDir",
+    '--output-dir=$tempDir',
     ...filesInTheRightDirectory.skip(1),
   ];
   var result = Process.run(dart, args,
@@ -156,10 +156,10 @@ Future<ProcessResult> run(
 void checkResult(ProcessResult result) {
   if (result != null) {
     if (result.exitCode != 0) {
-      print("Error running sub-program:");
+      print('Error running sub-program:');
       print(result.stdout);
       print(result.stderr);
-      print("exitCode=${result.exitCode}");
+      print('exitCode=${result.exitCode}');
     }
 
     expect(result.exitCode, 0);

--- a/test/message_extraction/message_extraction_test.dart
+++ b/test/message_extraction/message_extraction_test.dart
@@ -42,7 +42,7 @@ String _createTempDir() => useLocalDirectory
     ? '.'
     : Directory.systemTemp.createTempSync('message_extraction_test').path;
 
-var useLocalDirectory = false;
+bool useLocalDirectory = false;
 
 /// Translate a relative file path into this test directory. This is
 /// applied to all the arguments of [run]. It will ignore a string that

--- a/test/message_extraction/message_extraction_test.dart
+++ b/test/message_extraction/message_extraction_test.dart
@@ -64,7 +64,7 @@ String asTempDirPath([String s]) {
 
 typedef ThenResult = Future<ProcessResult> Function(ProcessResult _);
 
-main() {
+void main() {
   setUp(copyFilesToTempDirectory);
   tearDown(deleteGeneratedFiles);
   test(
@@ -142,26 +142,27 @@ Future<ProcessResult> run(
       .toList();
   // Inject the script argument --output-dir in between the script and its
   // arguments.
-  List<String> args = [...vmArgs, filesInTheRightDirectory.first, "--output-dir=$tempDir", ...filesInTheRightDirectory.skip(1)]
-    
-    
-    
-    ;
+  List<String> args = [
+    ...vmArgs,
+    filesInTheRightDirectory.first,
+    "--output-dir=$tempDir",
+    ...filesInTheRightDirectory.skip(1),
+  ];
   var result = Process.run(dart, args,
       stdoutEncoding: Utf8Codec(), stderrEncoding: Utf8Codec());
   return result;
 }
 
-checkResult(ProcessResult previousResult) {
-  if (previousResult != null) {
-    if (previousResult.exitCode != 0) {
+void checkResult(ProcessResult result) {
+  if (result != null) {
+    if (result.exitCode != 0) {
       print("Error running sub-program:");
+      print(result.stdout);
+      print(result.stderr);
+      print("exitCode=${result.exitCode}");
     }
-    print(previousResult.stdout);
-    print(previousResult.stderr);
-    print("exitCode=${previousResult.exitCode}");
-    // Fail the test.
-    expect(previousResult.exitCode, 0);
+
+    expect(result.exitCode, 0);
   }
 }
 

--- a/test/message_extraction/mock_flutter/foo_messages_de_DE.dart
+++ b/test/message_extraction/mock_flutter/foo_messages_de_DE.dart
@@ -6,6 +6,6 @@ library keep_the_static_analysis_from_complaining;
 
 class MessageLookup {
   String get messages => throw UnimplementedError(
-      'This entire file is only here to make the static'
-      ' analysis happy. It will be generated during actual tests.');
+    'This entire file is only here to make the static'
+    ' analysis happy. It will be generated during actual tests.');
 }

--- a/test/message_extraction/mock_flutter/foo_messages_de_DE.dart
+++ b/test/message_extraction/mock_flutter/foo_messages_de_DE.dart
@@ -6,6 +6,6 @@ library keep_the_static_analysis_from_complaining;
 
 class MessageLookup {
   String get messages => throw UnimplementedError(
-    'This entire file is only here to make the static'
-    ' analysis happy. It will be generated during actual tests.');
+      'This entire file is only here to make the static'
+      ' analysis happy. It will be generated during actual tests.');
 }

--- a/test/message_extraction/mock_flutter/foo_messages_de_DE.dart
+++ b/test/message_extraction/mock_flutter/foo_messages_de_DE.dart
@@ -5,7 +5,7 @@
 library keep_the_static_analysis_from_complaining;
 
 class MessageLookup {
-  String get messages => throw new UnimplementedError(
-    "This entire file is only here to make the static"
-    " analysis happy. It will be generated during actual tests.");
+  String get messages => throw UnimplementedError(
+    'This entire file is only here to make the static'
+    ' analysis happy. It will be generated during actual tests.');
 }

--- a/test/message_extraction/mock_flutter/foo_messages_fr.dart
+++ b/test/message_extraction/mock_flutter/foo_messages_fr.dart
@@ -6,6 +6,6 @@ library keep_the_static_analysis_from_complaining;
 
 class MessageLookup {
   String get messages => throw UnimplementedError(
-      'This entire file is only here to make the static'
-      ' analysis happy. It will be generated during actual tests.');
+    'This entire file is only here to make the static'
+    ' analysis happy. It will be generated during actual tests.');
 }

--- a/test/message_extraction/mock_flutter/foo_messages_fr.dart
+++ b/test/message_extraction/mock_flutter/foo_messages_fr.dart
@@ -6,6 +6,6 @@ library keep_the_static_analysis_from_complaining;
 
 class MessageLookup {
   String get messages => throw UnimplementedError(
-    'This entire file is only here to make the static'
-    ' analysis happy. It will be generated during actual tests.');
+      'This entire file is only here to make the static'
+      ' analysis happy. It will be generated during actual tests.');
 }

--- a/test/message_extraction/mock_flutter/foo_messages_fr.dart
+++ b/test/message_extraction/mock_flutter/foo_messages_fr.dart
@@ -5,7 +5,7 @@
 library keep_the_static_analysis_from_complaining;
 
 class MessageLookup {
-  String get messages => throw new UnimplementedError(
-    "This entire file is only here to make the static"
-    " analysis happy. It will be generated during actual tests.");
+  String get messages => throw UnimplementedError(
+    'This entire file is only here to make the static'
+    ' analysis happy. It will be generated during actual tests.');
 }

--- a/test/message_extraction/mock_flutter/services.dart
+++ b/test/message_extraction/mock_flutter/services.dart
@@ -31,9 +31,9 @@ class MethodChannel {
 class AssetBundle {
   Future<String> loadString(String key, {bool cache = true}) async {
     // We only have two locales in the test.
-    if (key.contains("fr")) {
+    if (key.contains('fr')) {
       return jsonEncode(fr.MessageLookup().messages);
-    } else if (key.contains("de-DE")) {
+    } else if (key.contains('de-DE')) {
       return jsonEncode(de_de.MessageLookup().messages);
     }
     return null;

--- a/test/message_extraction/part_of_sample_with_messages.dart
+++ b/test/message_extraction/part_of_sample_with_messages.dart
@@ -2,16 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.part of sample;
 
-// ignore_for_file: unnecessary_string_interpolations
-
-// Note - the above ignore is necessary for the integration tests to pass.
-
 part of sample;
 
 class Person {
-  final String name;
-  final String gender;
-
+  String name;
+  String gender;
   Person(this.name, this.gender);
 }
 
@@ -68,7 +63,7 @@ class YouveGotMessages {
   }
 
   // English doesn't do enough with genders, so this example is French.
-  String nested(List<Person> people, String place) {
+  String nested(List people, String place) {
     var names = people.map((x) => x.name).join(', ');
     var number = people.length;
     var combinedGender =

--- a/test/message_extraction/part_of_sample_with_messages.dart
+++ b/test/message_extraction/part_of_sample_with_messages.dart
@@ -2,6 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.part of sample;
 
+// ignore_for_file: unnecessary_string_interpolations
+
+// Note - the above ignore is necessary for the integration tests to pass.
+
 part of sample;
 
 class Person {

--- a/test/message_extraction/part_of_sample_with_messages.dart
+++ b/test/message_extraction/part_of_sample_with_messages.dart
@@ -79,8 +79,8 @@ class YouveGotMessages {
           other: '${Intl.plural(
             number,
             zero: "Personne n'est allé au $place",
-            one: "${names} est allé au $place",
-            other: "${names} sont allés au $place",
+            one: "$names est allé au $place",
+            other: "$names sont allés au $place",
           )}',
           female: '${Intl.plural(
             number,

--- a/test/message_extraction/part_of_sample_with_messages.dart
+++ b/test/message_extraction/part_of_sample_with_messages.dart
@@ -9,15 +9,17 @@
 part of sample;
 
 class Person {
-  String name;
-  String gender;
+  final String name;
+  final String gender;
+
   Person(this.name, this.gender);
 }
 
 class YouveGotMessages {
   // A static message, rather than a standalone function.
-  static String staticMessage() => Intl.message('This comes from a static method',
-      name: 'staticMessage', desc: 'Static');
+  static String staticMessage() =>
+      Intl.message('This comes from a static method',
+          name: 'staticMessage', desc: 'Static');
 
   // An instance method, rather than a standalone function.
   String method() => Intl.message('This comes from a method',
@@ -66,7 +68,7 @@ class YouveGotMessages {
   }
 
   // English doesn't do enough with genders, so this example is French.
-  String nested(List people, String place) {
+  String nested(List<Person> people, String place) {
     var names = people.map((x) => x.name).join(', ');
     var number = people.length;
     var combinedGender =

--- a/test/message_extraction/part_of_sample_with_messages.dart
+++ b/test/message_extraction/part_of_sample_with_messages.dart
@@ -16,11 +16,11 @@ class Person {
 
 class YouveGotMessages {
   // A static message, rather than a standalone function.
-  static staticMessage() => Intl.message("This comes from a static method",
-      name: 'staticMessage', desc: "Static");
+  static staticMessage() => Intl.message('This comes from a static method',
+      name: 'staticMessage', desc: 'Static');
 
   // An instance method, rather than a standalone function.
-  method() => Intl.message("This comes from a method",
+  method() => Intl.message('This comes from a method',
       name: 'YouveGotMessages_method',
       desc: 'This is a method with a '
           'long description which spans '
@@ -30,10 +30,10 @@ class YouveGotMessages {
   // before the Intl.message call.
   nonLambda() {
     var aTrueValue = true;
-    var msg = Intl.message("This method is not a lambda",
-        name: 'nonLambda', desc: "Not a lambda");
+    var msg = Intl.message('This method is not a lambda',
+        name: 'nonLambda', desc: 'Not a lambda');
     if (!aTrueValue) {
-      throw new AssertionError('Parser should not fail with additional code.');
+      throw AssertionError('Parser should not fail with additional code.');
     }
     return msg;
   }
@@ -45,9 +45,9 @@ class YouveGotMessages {
         one: 'This is singular.',
         other: 'This is plural ($num).',
       )}""",
-      name: "plurals",
+      name: 'plurals',
       args: [num],
-      desc: "Basic plurals");
+      desc: 'Basic plurals');
 
   whereTheyWent(Person person, String place) =>
       whereTheyWentMessage(person.name, person.gender, place);
@@ -60,18 +60,18 @@ class YouveGotMessages {
           female: '$name went to her $place',
           other: '$name went to its $place',
         )}",
-        name: "whereTheyWentMessage",
+        name: 'whereTheyWentMessage',
         args: [name, gender, place],
         desc: 'A person went to some place that they own, e.g. their room');
   }
 
   // English doesn't do enough with genders, so this example is French.
   nested(List people, String place) {
-    var names = people.map((x) => x.name).join(", ");
+    var names = people.map((x) => x.name).join(', ');
     var number = people.length;
     var combinedGender =
-        people.every((x) => x.gender == "female") ? "female" : "other";
-    if (number == 0) combinedGender = "other";
+        people.every((x) => x.gender == 'female') ? 'female' : 'other';
+    if (number == 0) combinedGender = 'other';
 
     nestedMessage(names, number, combinedGender, place) => Intl.message(
         '''${Intl.gender(
@@ -88,8 +88,8 @@ class YouveGotMessages {
             other: "$names sont allées au $place",
           )}',
         )}''',
-        desc: "Nested message example",
-        name: "nestedMessage",
+        desc: 'Nested message example',
+        name: 'nestedMessage',
         args: [names, number, combinedGender, place]);
     return nestedMessage(names, number, combinedGender, place);
   }

--- a/test/message_extraction/part_of_sample_with_messages.dart
+++ b/test/message_extraction/part_of_sample_with_messages.dart
@@ -16,11 +16,11 @@ class Person {
 
 class YouveGotMessages {
   // A static message, rather than a standalone function.
-  static staticMessage() => Intl.message('This comes from a static method',
+  static String staticMessage() => Intl.message('This comes from a static method',
       name: 'staticMessage', desc: 'Static');
 
   // An instance method, rather than a standalone function.
-  method() => Intl.message('This comes from a method',
+  String method() => Intl.message('This comes from a method',
       name: 'YouveGotMessages_method',
       desc: 'This is a method with a '
           'long description which spans '
@@ -28,7 +28,7 @@ class YouveGotMessages {
 
   // A non-lambda, i.e. not using => syntax, and with an additional statement
   // before the Intl.message call.
-  nonLambda() {
+  String nonLambda() {
     var aTrueValue = true;
     var msg = Intl.message('This method is not a lambda',
         name: 'nonLambda', desc: 'Not a lambda');
@@ -38,7 +38,7 @@ class YouveGotMessages {
     return msg;
   }
 
-  plurals(num num) => Intl.message(
+  String plurals(num num) => Intl.message(
       """${Intl.plural(
         num,
         zero: 'Is zero plural?',
@@ -49,10 +49,10 @@ class YouveGotMessages {
       args: [num],
       desc: 'Basic plurals');
 
-  whereTheyWent(Person person, String place) =>
+  dynamic whereTheyWent(Person person, String place) =>
       whereTheyWentMessage(person.name, person.gender, place);
 
-  whereTheyWentMessage(String name, String gender, String place) {
+  String whereTheyWentMessage(String name, String gender, String place) {
     return Intl.message(
         "${Intl.gender(
           gender,
@@ -66,14 +66,14 @@ class YouveGotMessages {
   }
 
   // English doesn't do enough with genders, so this example is French.
-  nested(List people, String place) {
+  String nested(List people, String place) {
     var names = people.map((x) => x.name).join(', ');
     var number = people.length;
     var combinedGender =
         people.every((x) => x.gender == 'female') ? 'female' : 'other';
     if (number == 0) combinedGender = 'other';
 
-    nestedMessage(names, number, combinedGender, place) => Intl.message(
+    String nestedMessage(names, number, combinedGender, place) => Intl.message(
         '''${Intl.gender(
           combinedGender,
           other: '${Intl.plural(

--- a/test/message_extraction/really_fail_extraction_test.dart
+++ b/test/message_extraction/really_fail_extraction_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(const Duration(seconds: 180))
-
 library really_fail_extraction_test;
 
 import "package:test/test.dart";

--- a/test/message_extraction/really_fail_extraction_test.dart
+++ b/test/message_extraction/really_fail_extraction_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 import 'failed_extraction_test.dart';
 
-main() {
+void main() {
   test('Expect failure because warnings are errors', () {
     runTestWithWarnings(warningsAreErrors: true, expectedExitCode: 1);
   });

--- a/test/message_extraction/really_fail_extraction_test.dart
+++ b/test/message_extraction/really_fail_extraction_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Timeout(Duration(seconds: 180))
+
 library really_fail_extraction_test;
 
 import 'package:test/test.dart';

--- a/test/message_extraction/really_fail_extraction_test.dart
+++ b/test/message_extraction/really_fail_extraction_test.dart
@@ -4,12 +4,12 @@
 
 library really_fail_extraction_test;
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
-import "failed_extraction_test.dart";
+import 'failed_extraction_test.dart';
 
 main() {
-  test("Expect failure because warnings are errors", () {
+  test('Expect failure because warnings are errors', () {
     runTestWithWarnings(warningsAreErrors: true, expectedExitCode: 1);
   });
 }

--- a/test/message_extraction/run_and_verify.dart
+++ b/test/message_extraction/run_and_verify.dart
@@ -6,7 +6,7 @@ library verify_and_run;
 import 'dart:convert';
 import 'dart:io';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 import 'sample_with_messages.dart' as sample;
 import 'verify_messages.dart';
@@ -17,19 +17,19 @@ main(List<String> args) {
     exit(0);
   }
 
-  test("Verify message translation output", () async {
+  test('Verify message translation output', () async {
     await sample.main();
     verifyResult();
   });
 
-  test("Messages with skipExtraction set should not be extracted", () {
+  test('Messages with skipExtraction set should not be extracted', () {
     var fileArgs = args.where((x) => x.contains('.arb'));
     var messages =
         JsonCodec().decode(File(fileArgs.first).readAsStringSync());
     messages.forEach((name, _) {
       // Assume any name with 'skip' in it should not have been extracted.
       expect(name, isNot(contains('skip')),
-          reason: "A skipped message was extracted.");
+          reason: 'A skipped message was extracted.');
     });
   });
 }

--- a/test/message_extraction/run_and_verify.dart
+++ b/test/message_extraction/run_and_verify.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 import 'sample_with_messages.dart' as sample;
 import 'verify_messages.dart';
 
-main(List<String> args) {
+void main(List<String> args) {
   if (args.isEmpty) {
     print('Usage: run_and_verify [message_file.arb]');
     exit(0);
@@ -24,8 +24,7 @@ main(List<String> args) {
 
   test('Messages with skipExtraction set should not be extracted', () {
     var fileArgs = args.where((x) => x.contains('.arb'));
-    var messages =
-        JsonCodec().decode(File(fileArgs.first).readAsStringSync());
+    var messages = JsonCodec().decode(File(fileArgs.first).readAsStringSync());
     messages.forEach((name, _) {
       // Assume any name with 'skip' in it should not have been extracted.
       expect(name, isNot(contains('skip')),

--- a/test/message_extraction/run_and_verify.dart
+++ b/test/message_extraction/run_and_verify.dart
@@ -6,30 +6,31 @@ library verify_and_run;
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:test/test.dart';
+// TODO(devoncarew): See the comment below about restoring this testing.
+// import 'sample_with_messages.dart' as sample;
+// import 'verify_messages.dart';
 
-import 'sample_with_messages.dart' as sample;
-import 'verify_messages.dart';
-
-void main(List<String> args) {
+void main(List<String> args) async {
   if (args.isEmpty) {
     print('Usage: run_and_verify [message_file.arb]');
     exit(0);
   }
 
-  test('Verify message translation output', () async {
-    await sample.main();
-    verifyResult();
-  });
+  // TODO(devoncarew): This disables the verification of the generated code.
+  // We'll want to restore testing it, but likely move to a more hygenic
+  // integration style test, or, use a technique like golden masters.
+  // // Verify message translation output
+  // await sample.main();
+  // verifyResult();
 
-  test('Messages with skipExtraction set should not be extracted', () {
-    var fileArgs = args.where((x) => x.contains('.arb'));
-    Map<String, dynamic> messages =
-        JsonCodec().decode(File(fileArgs.first).readAsStringSync());
-    messages.forEach((name, _) {
-      // Assume any name with 'skip' in it should not have been extracted.
-      expect(name, isNot(contains('skip')),
-          reason: 'A skipped message was extracted.');
-    });
+  // Messages with skipExtraction set should not be extracted.
+  var fileArgs = args.where((x) => x.contains('.arb'));
+  Map<String, dynamic> messages =
+      jsonDecode(File(fileArgs.first).readAsStringSync());
+  messages.forEach((name, _) {
+    // Assume any name with 'skip' in it should not have been extracted.
+    if (name.contains('skip')) {
+      throw 'A skipped message was extracted: $name';
+    }
   });
 }

--- a/test/message_extraction/run_and_verify.dart
+++ b/test/message_extraction/run_and_verify.dart
@@ -6,9 +6,8 @@ library verify_and_run;
 import 'dart:convert';
 import 'dart:io';
 
-// TODO(devoncarew): See the comment below about restoring this testing.
-// import 'sample_with_messages.dart' as sample;
-// import 'verify_messages.dart';
+import 'sample_with_messages.dart' as sample;
+import 'verify_messages.dart';
 
 void main(List<String> args) async {
   if (args.isEmpty) {
@@ -16,21 +15,18 @@ void main(List<String> args) async {
     exit(0);
   }
 
-  // TODO(devoncarew): This disables the verification of the generated code.
-  // We'll want to restore testing it, but likely move to a more hygenic
-  // integration style test, or, use a technique like golden masters.
-  // // Verify message translation output
-  // await sample.main();
-  // verifyResult();
+  // Verify message translation output
+  await sample.main();
+  verifyResult();
 
-  // Messages with skipExtraction set should not be extracted.
+  // Messages with skipExtraction set should not be extracted
   var fileArgs = args.where((x) => x.contains('.arb'));
-  Map<String, dynamic> messages =
-      jsonDecode(File(fileArgs.first).readAsStringSync());
+  var messages = jsonDecode(File(fileArgs.first).readAsStringSync())
+      as Map<String, dynamic>;
   messages.forEach((name, _) {
     // Assume any name with 'skip' in it should not have been extracted.
     if (name.contains('skip')) {
-      throw 'A skipped message was extracted: $name';
+      throw "A skipped message was extracted ('$name')";
     }
   });
 }

--- a/test/message_extraction/run_and_verify.dart
+++ b/test/message_extraction/run_and_verify.dart
@@ -25,7 +25,7 @@ main(List<String> args) {
   test("Messages with skipExtraction set should not be extracted", () {
     var fileArgs = args.where((x) => x.contains('.arb'));
     var messages =
-        new JsonCodec().decode(new File(fileArgs.first).readAsStringSync());
+        JsonCodec().decode(File(fileArgs.first).readAsStringSync());
     messages.forEach((name, _) {
       // Assume any name with 'skip' in it should not have been extracted.
       expect(name, isNot(contains('skip')),

--- a/test/message_extraction/run_and_verify.dart
+++ b/test/message_extraction/run_and_verify.dart
@@ -24,7 +24,8 @@ void main(List<String> args) {
 
   test('Messages with skipExtraction set should not be extracted', () {
     var fileArgs = args.where((x) => x.contains('.arb'));
-    var messages = JsonCodec().decode(File(fileArgs.first).readAsStringSync());
+    Map<String, dynamic> messages =
+        JsonCodec().decode(File(fileArgs.first).readAsStringSync());
     messages.forEach((name, _) {
       // Assume any name with 'skip' in it should not have been extracted.
       expect(name, isNot(contains('skip')),

--- a/test/message_extraction/sample_with_messages.dart
+++ b/test/message_extraction/sample_with_messages.dart
@@ -13,7 +13,8 @@ import 'print_to_list.dart';
 
 part 'part_of_sample_with_messages.dart';
 
-String message1() => Intl.message('This is a message', name: 'message1', desc: 'foo');
+String message1() =>
+    Intl.message('This is a message', name: 'message1', desc: 'foo');
 
 String message2(x) => Intl.message('Another message with parameter $x',
     name: 'mess' 'age2',
@@ -57,8 +58,9 @@ String originalNotInBMP() =>
     Intl.message('Ancient Greek hangman characters: 𐅆𐅇.', desc: 'non-BMP');
 
 // A string for which we don't provide all translations.
-String notAlwaysTranslated() => Intl.message('This is missing some translations',
-    name: 'notAlwaysTranslated', desc: 'Not always translated');
+String notAlwaysTranslated() =>
+    Intl.message('This is missing some translations',
+        name: 'notAlwaysTranslated', desc: 'Not always translated');
 
 // This is invalid and should be recognized as such, because the message has
 // to be a literal. Otherwise, interpolations would be outside of the function
@@ -122,8 +124,8 @@ String failedSelect(currency) => Intl.select(
 String nestedSelect(currency, amount) => Intl.select(
     currency,
     {
-      'CDN':
-          Intl.plural(amount, one: '$amount Canadian dollar', other: '$amount Canadian dollars'),
+      'CDN': Intl.plural(amount,
+          one: '$amount Canadian dollar', other: '$amount Canadian dollars'),
       'other': 'Whatever',
     },
     name: 'nestedSelect',
@@ -202,7 +204,7 @@ String skipMessageExistingTranslation() =>
         skip: true,
         desc: 'Skip with existing translation');
 
-printStuff(Intl locale) {
+void printStuff(Intl locale) {
   // Use a name that's not a literal so this will get skipped. Then we have
   // a name that's not in the original but we include it in the French
   // translation. Because it's not in the original it shouldn't get included

--- a/test/message_extraction/sample_with_messages.dart
+++ b/test/message_extraction/sample_with_messages.dart
@@ -10,6 +10,7 @@
 library sample;
 
 import 'package:intl/intl.dart';
+
 import 'foo_messages_all.dart';
 import 'print_to_list.dart';
 

--- a/test/message_extraction/sample_with_messages.dart
+++ b/test/message_extraction/sample_with_messages.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: type_annotate_public_apis
-
 /// This is a program with various [Intl.message] messages. It just prints
 /// all of them, and is used for testing of message extraction, translation,
 /// and code generation.
@@ -19,7 +17,7 @@ part 'part_of_sample_with_messages.dart';
 String message1() =>
     Intl.message('This is a message', name: 'message1', desc: 'foo');
 
-String message2(Object x) => Intl.message('Another message with parameter $x',
+String message2(String x) => Intl.message('Another message with parameter $x',
     name: 'mess' 'age2',
     desc: 'Description ' '2',
     args: [x],
@@ -68,7 +66,7 @@ String notAlwaysTranslated() =>
 // This is invalid and should be recognized as such, because the message has
 // to be a literal. Otherwise, interpolations would be outside of the function
 // scope.
-var someString = 'No, it has to be a literal string';
+String someString = 'No, it has to be a literal string';
 String noVariables() => Intl.message(someString,
     name: 'noVariables', desc: 'Invalid. Not a literal');
 
@@ -77,7 +75,7 @@ String noVariables() => Intl.message(someString,
 String escapable() => Intl.message('Escapable characters here: ',
     name: 'escapable', desc: 'Escapable characters');
 
-String outerPlural(n) => Intl.plural(n,
+String outerPlural(num n) => Intl.plural(n,
     zero: 'none',
     one: 'one',
     other: 'some',
@@ -85,7 +83,7 @@ String outerPlural(n) => Intl.plural(n,
     desc: 'A plural with no enclosing message',
     args: [n]);
 
-String outerGender(g) => Intl.gender(g,
+String outerGender(String g) => Intl.gender(g,
     male: 'm',
     female: 'f',
     other: 'o',
@@ -93,7 +91,7 @@ String outerGender(g) => Intl.gender(g,
     desc: 'A gender with no enclosing message',
     args: [g]);
 
-String pluralThatFailsParsing(noOfThings) => Intl.plural(noOfThings,
+String pluralThatFailsParsing(num noOfThings) => Intl.plural(noOfThings,
     one: '1 thing:',
     other: '$noOfThings things:',
     name: 'pluralThatFailsParsing',
@@ -102,11 +100,11 @@ String pluralThatFailsParsing(noOfThings) => Intl.plural(noOfThings,
 
 // A standalone gender message where we don't provide name or args. This should
 // be rejected by validation code.
-String invalidOuterGender(g) =>
+String invalidOuterGender(String g) =>
     Intl.gender(g, other: 'o', desc: 'Invalid outer gender');
 
 // A general select
-String outerSelect(currency, amount) => Intl.select(
+String outerSelect(String currency, num amount) => Intl.select(
     currency,
     {
       'CDN': '$amount Canadian dollars',
@@ -119,12 +117,12 @@ String outerSelect(currency, amount) => Intl.select(
 // An invalid select which should never appear. Unfortunately
 // it's difficult to write an automated test for this, you
 // just should be able to note a warning for it when extracting.
-String failedSelect(currency) => Intl.select(
+String failedSelect(String currency) => Intl.select(
     currency, {'this.should.fail': 'not valid', 'other': "doesn't matter"},
     name: 'failedSelect', args: [currency], desc: 'Invalid select');
 
 // A select with a plural inside the expressions.
-String nestedSelect(currency, amount) => Intl.select(
+String nestedSelect(String currency, num amount) => Intl.select(
     currency,
     {
       'CDN': Intl.plural(amount,
@@ -137,7 +135,7 @@ String nestedSelect(currency, amount) => Intl.select(
 
 // A trivial nested plural/gender where both are done directly rather than
 // in interpolations.
-String nestedOuter(number, gen) => Intl.plural(number,
+String nestedOuter(num number, String gen) => Intl.plural(number,
     other: Intl.gender(gen, male: '$number male', other: '$number other'),
     name: 'nestedOuter',
     args: [number, gen],
@@ -172,7 +170,7 @@ String extractable() => Intl.message('This message should be extractable',
 String skipMessage() => Intl.message('This message should skip extraction',
     skip: true, desc: 'Skipped message');
 
-String skipPlural(n) => Intl.plural(n,
+String skipPlural(num n) => Intl.plural(n,
     zero: 'Extraction skipped plural none',
     one: 'Extraction skipped plural one',
     other: 'Extraction skipped plural some',
@@ -181,7 +179,7 @@ String skipPlural(n) => Intl.plural(n,
     args: [n],
     skip: true);
 
-String skipGender(g) => Intl.gender(g,
+String skipGender(String g) => Intl.gender(g,
     male: 'Extraction skipped gender m',
     female: 'Extraction skipped gender f',
     other: 'Extraction skipped gender o',

--- a/test/message_extraction/sample_with_messages.dart
+++ b/test/message_extraction/sample_with_messages.dart
@@ -50,7 +50,7 @@ String trickyInterpolation(s) =>
     Intl.message('Interpolation is tricky when it ends a sentence like $s.',
         name: 'trickyInterpolation', args: [s], desc: 'interpolation');
 
-String get leadingQuotes => Intl.message('\"So-called\"', desc: 'so-called');
+String get leadingQuotes => Intl.message('"So-called"', desc: 'so-called');
 
 // A message with characters not in the basic multilingual plane.
 String originalNotInBMP() =>
@@ -219,7 +219,7 @@ printStuff(Intl locale) {
   // within another function definition.
   String message3(a, b, c) => Intl.message(
       'Characters that need escaping, e.g slashes \\ dollars \${ (curly braces '
-      'are ok) and xml reserved characters <& and quotes \" '
+      'are ok) and xml reserved characters <& and quotes " '
       'parameters $a, $b, and $c',
       desc: 'Lots of escapes',
       name: 'message3',

--- a/test/message_extraction/sample_with_messages.dart
+++ b/test/message_extraction/sample_with_messages.dart
@@ -7,15 +7,15 @@
 /// and code generation.
 library sample;
 
-import "package:intl/intl.dart";
-import "foo_messages_all.dart";
-import "print_to_list.dart";
+import 'package:intl/intl.dart';
+import 'foo_messages_all.dart';
+import 'print_to_list.dart';
 
 part 'part_of_sample_with_messages.dart';
 
-String message1() => Intl.message("This is a message", name: 'message1', desc: 'foo');
+String message1() => Intl.message('This is a message', name: 'message1', desc: 'foo');
 
-String message2(x) => Intl.message("Another message with parameter $x",
+String message2(x) => Intl.message('Another message with parameter $x',
     name: 'mess' 'age2',
     desc: 'Description ' '2',
     args: [x],
@@ -24,53 +24,53 @@ String message2(x) => Intl.message("Another message with parameter $x",
 // A string with multiple adjacent strings concatenated together, verify
 // that the parser handles this properly.
 String multiLine() => Intl.message(
-    "This "
-    "string "
-    "extends "
-    "across "
-    "multiple "
-    "lines.",
-    desc: "multi-line");
+    'This '
+    'string '
+    'extends '
+    'across '
+    'multiple '
+    'lines.',
+    desc: 'multi-line');
 
 String get interestingCharactersNoName =>
-    Intl.message("'<>{}= +-_\$()&^%\$#@!~`'", desc: "interesting characters");
+    Intl.message("'<>{}= +-_\$()&^%\$#@!~`'", desc: 'interesting characters');
 
 // Have types on the enclosing function's arguments.
 String types(int a, String b, List c) =>
-    Intl.message("$a, $b, $c", name: 'types', args: [a, b, c], desc: 'types');
+    Intl.message('$a, $b, $c', name: 'types', args: [a, b, c], desc: 'types');
 
 // This string will be printed with a French locale, so it will always show
 // up in the French version, regardless of the current locale.
-String alwaysTranslated() => Intl.message("This string is always translated",
+String alwaysTranslated() => Intl.message('This string is always translated',
     locale: 'fr', name: 'alwaysTranslated', desc: 'always translated');
 
 // Test interpolation with curly braces around the expression, but it must
 // still be just a variable reference.
 String trickyInterpolation(s) =>
-    Intl.message("Interpolation is tricky when it ends a sentence like $s.",
+    Intl.message('Interpolation is tricky when it ends a sentence like $s.',
         name: 'trickyInterpolation', args: [s], desc: 'interpolation');
 
-String get leadingQuotes => Intl.message("\"So-called\"", desc: "so-called");
+String get leadingQuotes => Intl.message('\"So-called\"', desc: 'so-called');
 
 // A message with characters not in the basic multilingual plane.
 String originalNotInBMP() =>
-    Intl.message("Ancient Greek hangman characters: 𐅆𐅇.", desc: "non-BMP");
+    Intl.message('Ancient Greek hangman characters: 𐅆𐅇.', desc: 'non-BMP');
 
 // A string for which we don't provide all translations.
-String notAlwaysTranslated() => Intl.message("This is missing some translations",
-    name: "notAlwaysTranslated", desc: "Not always translated");
+String notAlwaysTranslated() => Intl.message('This is missing some translations',
+    name: 'notAlwaysTranslated', desc: 'Not always translated');
 
 // This is invalid and should be recognized as such, because the message has
 // to be a literal. Otherwise, interpolations would be outside of the function
 // scope.
-var someString = "No, it has to be a literal string";
+var someString = 'No, it has to be a literal string';
 String noVariables() => Intl.message(someString,
-    name: "noVariables", desc: "Invalid. Not a literal");
+    name: 'noVariables', desc: 'Invalid. Not a literal');
 
 // This is unremarkable in English, but the translated versions will contain
 // characters that ought to be escaped during code generation.
-String escapable() => Intl.message("Escapable characters here: ",
-    name: "escapable", desc: "Escapable characters");
+String escapable() => Intl.message('Escapable characters here: ',
+    name: 'escapable', desc: 'Escapable characters');
 
 String outerPlural(n) => Intl.plural(n,
     zero: 'none',
@@ -89,83 +89,83 @@ String outerGender(g) => Intl.gender(g,
     args: [g]);
 
 String pluralThatFailsParsing(noOfThings) => Intl.plural(noOfThings,
-    one: "1 thing:",
-    other: "$noOfThings things:",
-    name: "pluralThatFailsParsing",
+    one: '1 thing:',
+    other: '$noOfThings things:',
+    name: 'pluralThatFailsParsing',
     args: [noOfThings],
-    desc: "How many things are there?");
+    desc: 'How many things are there?');
 
 // A standalone gender message where we don't provide name or args. This should
 // be rejected by validation code.
 String invalidOuterGender(g) =>
-    Intl.gender(g, other: 'o', desc: "Invalid outer gender");
+    Intl.gender(g, other: 'o', desc: 'Invalid outer gender');
 
 // A general select
 String outerSelect(currency, amount) => Intl.select(
     currency,
     {
-      "CDN": "$amount Canadian dollars",
-      "other": "$amount some currency or other."
+      'CDN': '$amount Canadian dollars',
+      'other': '$amount some currency or other.'
     },
-    name: "outerSelect",
-    desc: "Select",
+    name: 'outerSelect',
+    desc: 'Select',
     args: [currency, amount]);
 
 // An invalid select which should never appear. Unfortunately
 // it's difficult to write an automated test for this, you
 // just should be able to note a warning for it when extracting.
 String failedSelect(currency) => Intl.select(
-    currency, {"this.should.fail": "not valid", "other": "doesn't matter"},
-    name: "failedSelect", args: [currency], desc: "Invalid select");
+    currency, {'this.should.fail': 'not valid', 'other': "doesn't matter"},
+    name: 'failedSelect', args: [currency], desc: 'Invalid select');
 
 // A select with a plural inside the expressions.
 String nestedSelect(currency, amount) => Intl.select(
     currency,
     {
-      "CDN":
+      'CDN':
           Intl.plural(amount, one: '$amount Canadian dollar', other: '$amount Canadian dollars'),
-      "other": "Whatever",
+      'other': 'Whatever',
     },
-    name: "nestedSelect",
+    name: 'nestedSelect',
     args: [currency, amount],
-    desc: "Plural inside select");
+    desc: 'Plural inside select');
 
 // A trivial nested plural/gender where both are done directly rather than
 // in interpolations.
 String nestedOuter(number, gen) => Intl.plural(number,
-    other: Intl.gender(gen, male: "$number male", other: "$number other"),
+    other: Intl.gender(gen, male: '$number male', other: '$number other'),
     name: 'nestedOuter',
     args: [number, gen],
-    desc: "Gender inside plural");
+    desc: 'Gender inside plural');
 
-String sameContentsDifferentName() => Intl.message("Hello World",
-    name: "sameContentsDifferentName",
-    desc: "One of two messages with the same contents, but different names");
+String sameContentsDifferentName() => Intl.message('Hello World',
+    name: 'sameContentsDifferentName',
+    desc: 'One of two messages with the same contents, but different names');
 
-String differentNameSameContents() => Intl.message("Hello World",
-    name: "differentNameSameContents",
-    desc: "One of two messages with the same contents, but different names");
+String differentNameSameContents() => Intl.message('Hello World',
+    name: 'differentNameSameContents',
+    desc: 'One of two messages with the same contents, but different names');
 
 /// Distinguish two messages with identical text using the meaning parameter.
-String rentToBePaid() => Intl.message("rent",
-    name: "rentToBePaid",
+String rentToBePaid() => Intl.message('rent',
+    name: 'rentToBePaid',
     meaning: 'Money for rent',
-    desc: "Money to be paid for rent");
+    desc: 'Money to be paid for rent');
 
-String rentAsVerb() => Intl.message("rent",
-    name: "rentAsVerb",
+String rentAsVerb() => Intl.message('rent',
+    name: 'rentAsVerb',
     meaning: 'rent as a verb',
-    desc: "The action of renting, as in rent a car");
+    desc: 'The action of renting, as in rent a car');
 
-String literalDollar() => Intl.message("Five cents is US\$0.05",
-    name: "literalDollar", desc: "Literal dollar sign with valid number");
+String literalDollar() => Intl.message('Five cents is US\$0.05',
+    name: 'literalDollar', desc: 'Literal dollar sign with valid number');
 
 /// Messages for testing the skip flag.
 String extractable() => Intl.message('This message should be extractable',
-    name: "extractable", skip: false, desc: "Not skipped message");
+    name: 'extractable', skip: false, desc: 'Not skipped message');
 
 String skipMessage() => Intl.message('This message should skip extraction',
-    skip: true, desc: "Skipped message");
+    skip: true, desc: 'Skipped message');
 
 String skipPlural(n) => Intl.plural(n,
     zero: 'Extraction skipped plural none',
@@ -188,19 +188,19 @@ String skipGender(g) => Intl.gender(g,
 String skipSelect(name) => Intl.select(
     name,
     {
-      "Bob": "Extraction skipped select specified Bob!",
-      "other": "Extraction skipped select other $name"
+      'Bob': 'Extraction skipped select specified Bob!',
+      'other': 'Extraction skipped select other $name'
     },
-    name: "skipSelect",
-    desc: "Skipped select",
+    name: 'skipSelect',
+    desc: 'Skipped select',
     args: [name],
     skip: true);
 
 String skipMessageExistingTranslation() =>
     Intl.message('This message should skip translation',
-        name: "skipMessageExistingTranslation",
+        name: 'skipMessageExistingTranslation',
         skip: true,
-        desc: "Skip with existing translation");
+        desc: 'Skip with existing translation');
 
 printStuff(Intl locale) {
   // Use a name that's not a literal so this will get skipped. Then we have
@@ -208,9 +208,9 @@ printStuff(Intl locale) {
   // translation. Because it's not in the original it shouldn't get included
   // in the generated catalog and shouldn't get translated.
   if (locale.locale == 'fr') {
-    var badName = "thisNameIsNotInTheOriginal";
-    var notInOriginal = Intl.message("foo", name: badName);
-    if (notInOriginal != "foo") {
+    var badName = 'thisNameIsNotInTheOriginal';
+    var notInOriginal = Intl.message('foo', name: badName);
+    if (notInOriginal != 'foo') {
       throw "You shouldn't be able to introduce a new message in a translation";
     }
   }
@@ -218,25 +218,25 @@ printStuff(Intl locale) {
   // A function that is assigned to a variable. It's also nested
   // within another function definition.
   String message3(a, b, c) => Intl.message(
-      "Characters that need escaping, e.g slashes \\ dollars \${ (curly braces "
-      "are ok) and xml reserved characters <& and quotes \" "
-      "parameters $a, $b, and $c",
-      desc: "Lots of escapes",
+      'Characters that need escaping, e.g slashes \\ dollars \${ (curly braces '
+      'are ok) and xml reserved characters <& and quotes \" '
+      'parameters $a, $b, and $c',
+      desc: 'Lots of escapes',
       name: 'message3',
       args: [a, b, c]);
   var messageVariable = message3;
 
-  printOut("-------------------------------------------");
-  printOut("Printing messages for ${locale.locale}");
+  printOut('-------------------------------------------');
+  printOut('Printing messages for ${locale.locale}');
   Intl.withLocale(locale.locale, () {
     printOut(message1());
-    printOut(message2("hello"));
+    printOut(message2('hello'));
     printOut(messageVariable(1, 2, 3));
     printOut(multiLine());
-    printOut(types(1, "b", ["c", "d"]));
+    printOut(types(1, 'b', ['c', 'd']));
     printOut(leadingQuotes);
     printOut(alwaysTranslated());
-    printOut(trickyInterpolation("this"));
+    printOut(trickyInterpolation('this'));
     var thing = YouveGotMessages();
     printOut(thing.method());
     printOut(thing.nonLambda());
@@ -261,27 +261,27 @@ printStuff(Intl locale) {
     printOut(thing.plurals(100));
     printOut(thing.plurals(101));
     printOut(thing.plurals(100000));
-    var alice = Person("Alice", "female");
-    var bob = Person("Bob", "male");
-    var cat = Person("cat", null);
-    printOut(thing.whereTheyWent(alice, "house"));
-    printOut(thing.whereTheyWent(bob, "house"));
-    printOut(thing.whereTheyWent(cat, "litter box"));
-    printOut(thing.nested([alice, bob], "magasin"));
-    printOut(thing.nested([alice], "magasin"));
-    printOut(thing.nested([], "magasin"));
-    printOut(thing.nested([bob, bob], "magasin"));
-    printOut(thing.nested([alice, alice], "magasin"));
+    var alice = Person('Alice', 'female');
+    var bob = Person('Bob', 'male');
+    var cat = Person('cat', null);
+    printOut(thing.whereTheyWent(alice, 'house'));
+    printOut(thing.whereTheyWent(bob, 'house'));
+    printOut(thing.whereTheyWent(cat, 'litter box'));
+    printOut(thing.nested([alice, bob], 'magasin'));
+    printOut(thing.nested([alice], 'magasin'));
+    printOut(thing.nested([], 'magasin'));
+    printOut(thing.nested([bob, bob], 'magasin'));
+    printOut(thing.nested([alice, alice], 'magasin'));
 
     printOut(outerPlural(0));
     printOut(outerPlural(1));
-    printOut(outerGender("male"));
-    printOut(outerGender("female"));
-    printOut(nestedOuter(7, "male"));
-    printOut(outerSelect("CDN", 7));
-    printOut(outerSelect("EUR", 5));
-    printOut(nestedSelect("CDN", 1));
-    printOut(nestedSelect("CDN", 2));
+    printOut(outerGender('male'));
+    printOut(outerGender('female'));
+    printOut(nestedOuter(7, 'male'));
+    printOut(outerSelect('CDN', 7));
+    printOut(outerSelect('EUR', 5));
+    printOut(nestedSelect('CDN', 1));
+    printOut(nestedSelect('CDN', 2));
     printOut(pluralThatFailsParsing(1));
     printOut(pluralThatFailsParsing(2));
     printOut(differentNameSameContents());
@@ -294,8 +294,8 @@ printStuff(Intl locale) {
     printOut(extractable());
     printOut(skipMessage());
     printOut(skipPlural(1));
-    printOut(skipGender("female"));
-    printOut(skipSelect("Bob"));
+    printOut(skipGender('female'));
+    printOut(skipSelect('Bob'));
     printOut(skipMessageExistingTranslation());
   });
 }
@@ -303,16 +303,16 @@ printStuff(Intl locale) {
 var localeToUse = 'en_US';
 
 Future<List> main() {
-  var fr = Intl("fr");
-  var english = Intl("en_US");
-  var de = Intl("de_DE");
+  var fr = Intl('fr');
+  var english = Intl('en_US');
+  var de = Intl('de_DE');
   // Throw in an initialize of a null locale to make sure it doesn't throw.
   initializeMessages(null);
 
   // Verify that a translated message isn't initially present.
   var messageInGerman = Intl.withLocale('de_DE', message1);
-  if (messageInGerman != "This is a message") {
-    throw AssertionError("Translation error");
+  if (messageInGerman != 'This is a message') {
+    throw AssertionError('Translation error');
   }
 
   var f1 = initializeMessages(fr.locale)

--- a/test/message_extraction/sample_with_messages.dart
+++ b/test/message_extraction/sample_with_messages.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: type_annotate_public_apis
+
 /// This is a program with various [Intl.message] messages. It just prints
 /// all of them, and is used for testing of message extraction, translation,
 /// and code generation.
@@ -16,7 +18,7 @@ part 'part_of_sample_with_messages.dart';
 String message1() =>
     Intl.message('This is a message', name: 'message1', desc: 'foo');
 
-String message2(x) => Intl.message('Another message with parameter $x',
+String message2(Object x) => Intl.message('Another message with parameter $x',
     name: 'mess' 'age2',
     desc: 'Description ' '2',
     args: [x],
@@ -47,7 +49,7 @@ String alwaysTranslated() => Intl.message('This string is always translated',
 
 // Test interpolation with curly braces around the expression, but it must
 // still be just a variable reference.
-String trickyInterpolation(s) =>
+String trickyInterpolation(String s) =>
     Intl.message('Interpolation is tricky when it ends a sentence like $s.',
         name: 'trickyInterpolation', args: [s], desc: 'interpolation');
 
@@ -187,7 +189,7 @@ String skipGender(g) => Intl.gender(g,
     args: [g],
     skip: true);
 
-String skipSelect(name) => Intl.select(
+String skipSelect(String name) => Intl.select(
     name,
     {
       'Bob': 'Extraction skipped select specified Bob!',
@@ -302,7 +304,7 @@ void printStuff(Intl locale) {
   });
 }
 
-var localeToUse = 'en_US';
+String localeToUse = 'en_US';
 
 Future<List> main() {
   var fr = Intl('fr');

--- a/test/message_extraction/sample_with_messages.dart
+++ b/test/message_extraction/sample_with_messages.dart
@@ -13,9 +13,9 @@ import "print_to_list.dart";
 
 part 'part_of_sample_with_messages.dart';
 
-message1() => Intl.message("This is a message", name: 'message1', desc: 'foo');
+String message1() => Intl.message("This is a message", name: 'message1', desc: 'foo');
 
-message2(x) => Intl.message("Another message with parameter $x",
+String message2(x) => Intl.message("Another message with parameter $x",
     name: 'mess' 'age2',
     desc: 'Description ' '2',
     args: [x],
@@ -23,7 +23,7 @@ message2(x) => Intl.message("Another message with parameter $x",
 
 // A string with multiple adjacent strings concatenated together, verify
 // that the parser handles this properly.
-multiLine() => Intl.message(
+String multiLine() => Intl.message(
     "This "
     "string "
     "extends "
@@ -32,47 +32,47 @@ multiLine() => Intl.message(
     "lines.",
     desc: "multi-line");
 
-get interestingCharactersNoName =>
+String get interestingCharactersNoName =>
     Intl.message("'<>{}= +-_\$()&^%\$#@!~`'", desc: "interesting characters");
 
 // Have types on the enclosing function's arguments.
-types(int a, String b, List c) =>
+String types(int a, String b, List c) =>
     Intl.message("$a, $b, $c", name: 'types', args: [a, b, c], desc: 'types');
 
 // This string will be printed with a French locale, so it will always show
 // up in the French version, regardless of the current locale.
-alwaysTranslated() => Intl.message("This string is always translated",
+String alwaysTranslated() => Intl.message("This string is always translated",
     locale: 'fr', name: 'alwaysTranslated', desc: 'always translated');
 
 // Test interpolation with curly braces around the expression, but it must
 // still be just a variable reference.
-trickyInterpolation(s) =>
-    Intl.message("Interpolation is tricky when it ends a sentence like ${s}.",
+String trickyInterpolation(s) =>
+    Intl.message("Interpolation is tricky when it ends a sentence like $s.",
         name: 'trickyInterpolation', args: [s], desc: 'interpolation');
 
-get leadingQuotes => Intl.message("\"So-called\"", desc: "so-called");
+String get leadingQuotes => Intl.message("\"So-called\"", desc: "so-called");
 
 // A message with characters not in the basic multilingual plane.
-originalNotInBMP() =>
+String originalNotInBMP() =>
     Intl.message("Ancient Greek hangman characters: 𐅆𐅇.", desc: "non-BMP");
 
 // A string for which we don't provide all translations.
-notAlwaysTranslated() => Intl.message("This is missing some translations",
+String notAlwaysTranslated() => Intl.message("This is missing some translations",
     name: "notAlwaysTranslated", desc: "Not always translated");
 
 // This is invalid and should be recognized as such, because the message has
 // to be a literal. Otherwise, interpolations would be outside of the function
 // scope.
 var someString = "No, it has to be a literal string";
-noVariables() => Intl.message(someString,
+String noVariables() => Intl.message(someString,
     name: "noVariables", desc: "Invalid. Not a literal");
 
 // This is unremarkable in English, but the translated versions will contain
 // characters that ought to be escaped during code generation.
-escapable() => Intl.message("Escapable characters here: ",
+String escapable() => Intl.message("Escapable characters here: ",
     name: "escapable", desc: "Escapable characters");
 
-outerPlural(n) => Intl.plural(n,
+String outerPlural(n) => Intl.plural(n,
     zero: 'none',
     one: 'one',
     other: 'some',
@@ -80,7 +80,7 @@ outerPlural(n) => Intl.plural(n,
     desc: 'A plural with no enclosing message',
     args: [n]);
 
-outerGender(g) => Intl.gender(g,
+String outerGender(g) => Intl.gender(g,
     male: 'm',
     female: 'f',
     other: 'o',
@@ -88,7 +88,7 @@ outerGender(g) => Intl.gender(g,
     desc: 'A gender with no enclosing message',
     args: [g]);
 
-pluralThatFailsParsing(noOfThings) => Intl.plural(noOfThings,
+String pluralThatFailsParsing(noOfThings) => Intl.plural(noOfThings,
     one: "1 thing:",
     other: "$noOfThings things:",
     name: "pluralThatFailsParsing",
@@ -97,11 +97,11 @@ pluralThatFailsParsing(noOfThings) => Intl.plural(noOfThings,
 
 // A standalone gender message where we don't provide name or args. This should
 // be rejected by validation code.
-invalidOuterGender(g) =>
+String invalidOuterGender(g) =>
     Intl.gender(g, other: 'o', desc: "Invalid outer gender");
 
 // A general select
-outerSelect(currency, amount) => Intl.select(
+String outerSelect(currency, amount) => Intl.select(
     currency,
     {
       "CDN": "$amount Canadian dollars",
@@ -114,16 +114,16 @@ outerSelect(currency, amount) => Intl.select(
 // An invalid select which should never appear. Unfortunately
 // it's difficult to write an automated test for this, you
 // just should be able to note a warning for it when extracting.
-failedSelect(currency) => Intl.select(
+String failedSelect(currency) => Intl.select(
     currency, {"this.should.fail": "not valid", "other": "doesn't matter"},
     name: "failedSelect", args: [currency], desc: "Invalid select");
 
 // A select with a plural inside the expressions.
-nestedSelect(currency, amount) => Intl.select(
+String nestedSelect(currency, amount) => Intl.select(
     currency,
     {
       "CDN":
-          """${Intl.plural(amount, one: '$amount Canadian dollar', other: '$amount Canadian dollars')}""",
+          Intl.plural(amount, one: '$amount Canadian dollar', other: '$amount Canadian dollars'),
       "other": "Whatever",
     },
     name: "nestedSelect",
@@ -132,42 +132,42 @@ nestedSelect(currency, amount) => Intl.select(
 
 // A trivial nested plural/gender where both are done directly rather than
 // in interpolations.
-nestedOuter(number, gen) => Intl.plural(number,
+String nestedOuter(number, gen) => Intl.plural(number,
     other: Intl.gender(gen, male: "$number male", other: "$number other"),
     name: 'nestedOuter',
     args: [number, gen],
     desc: "Gender inside plural");
 
-sameContentsDifferentName() => Intl.message("Hello World",
+String sameContentsDifferentName() => Intl.message("Hello World",
     name: "sameContentsDifferentName",
     desc: "One of two messages with the same contents, but different names");
 
-differentNameSameContents() => Intl.message("Hello World",
+String differentNameSameContents() => Intl.message("Hello World",
     name: "differentNameSameContents",
     desc: "One of two messages with the same contents, but different names");
 
 /// Distinguish two messages with identical text using the meaning parameter.
-rentToBePaid() => Intl.message("rent",
+String rentToBePaid() => Intl.message("rent",
     name: "rentToBePaid",
     meaning: 'Money for rent',
     desc: "Money to be paid for rent");
 
-rentAsVerb() => Intl.message("rent",
+String rentAsVerb() => Intl.message("rent",
     name: "rentAsVerb",
     meaning: 'rent as a verb',
     desc: "The action of renting, as in rent a car");
 
-literalDollar() => Intl.message("Five cents is US\$0.05",
+String literalDollar() => Intl.message("Five cents is US\$0.05",
     name: "literalDollar", desc: "Literal dollar sign with valid number");
 
 /// Messages for testing the skip flag.
-extractable() => Intl.message('This message should be extractable',
+String extractable() => Intl.message('This message should be extractable',
     name: "extractable", skip: false, desc: "Not skipped message");
 
-skipMessage() => Intl.message('This message should skip extraction',
+String skipMessage() => Intl.message('This message should skip extraction',
     skip: true, desc: "Skipped message");
 
-skipPlural(n) => Intl.plural(n,
+String skipPlural(n) => Intl.plural(n,
     zero: 'Extraction skipped plural none',
     one: 'Extraction skipped plural one',
     other: 'Extraction skipped plural some',
@@ -176,7 +176,7 @@ skipPlural(n) => Intl.plural(n,
     args: [n],
     skip: true);
 
-skipGender(g) => Intl.gender(g,
+String skipGender(g) => Intl.gender(g,
     male: 'Extraction skipped gender m',
     female: 'Extraction skipped gender f',
     other: 'Extraction skipped gender o',
@@ -185,7 +185,7 @@ skipGender(g) => Intl.gender(g,
     args: [g],
     skip: true);
 
-skipSelect(name) => Intl.select(
+String skipSelect(name) => Intl.select(
     name,
     {
       "Bob": "Extraction skipped select specified Bob!",
@@ -196,7 +196,7 @@ skipSelect(name) => Intl.select(
     args: [name],
     skip: true);
 
-skipMessageExistingTranslation() =>
+String skipMessageExistingTranslation() =>
     Intl.message('This message should skip translation',
         name: "skipMessageExistingTranslation",
         skip: true,
@@ -217,7 +217,7 @@ printStuff(Intl locale) {
 
   // A function that is assigned to a variable. It's also nested
   // within another function definition.
-  message3(a, b, c) => Intl.message(
+  String message3(a, b, c) => Intl.message(
       "Characters that need escaping, e.g slashes \\ dollars \${ (curly braces "
       "are ok) and xml reserved characters <& and quotes \" "
       "parameters $a, $b, and $c",
@@ -237,7 +237,7 @@ printStuff(Intl locale) {
     printOut(leadingQuotes);
     printOut(alwaysTranslated());
     printOut(trickyInterpolation("this"));
-    var thing = new YouveGotMessages();
+    var thing = YouveGotMessages();
     printOut(thing.method());
     printOut(thing.nonLambda());
     printOut(YouveGotMessages.staticMessage());
@@ -261,9 +261,9 @@ printStuff(Intl locale) {
     printOut(thing.plurals(100));
     printOut(thing.plurals(101));
     printOut(thing.plurals(100000));
-    var alice = new Person("Alice", "female");
-    var bob = new Person("Bob", "male");
-    var cat = new Person("cat", null);
+    var alice = Person("Alice", "female");
+    var bob = Person("Bob", "male");
+    var cat = Person("cat", null);
     printOut(thing.whereTheyWent(alice, "house"));
     printOut(thing.whereTheyWent(bob, "house"));
     printOut(thing.whereTheyWent(cat, "litter box"));
@@ -302,17 +302,17 @@ printStuff(Intl locale) {
 
 var localeToUse = 'en_US';
 
-main() {
-  var fr = new Intl("fr");
-  var english = new Intl("en_US");
-  var de = new Intl("de_DE");
+Future<List> main() {
+  var fr = Intl("fr");
+  var english = Intl("en_US");
+  var de = Intl("de_DE");
   // Throw in an initialize of a null locale to make sure it doesn't throw.
   initializeMessages(null);
 
   // Verify that a translated message isn't initially present.
   var messageInGerman = Intl.withLocale('de_DE', message1);
   if (messageInGerman != "This is a message") {
-    throw new AssertionError("Translation error");
+    throw AssertionError("Translation error");
   }
 
   var f1 = initializeMessages(fr.locale)

--- a/test/message_extraction/verify_messages.dart
+++ b/test/message_extraction/verify_messages.dart
@@ -21,7 +21,7 @@ verifyResult() {
   verify('Another message with parameter hello');
   verify('Characters that need escaping, e.g slashes \\ dollars \${ '
       '(curly braces are ok) and xml reserved characters <& and '
-      'quotes \" parameters 1, 2, and 3');
+      'quotes " parameters 1, 2, and 3');
   verify('This string extends across multiple lines.');
   verify('1, b, [c, d]');
   verify('"So-called"');
@@ -89,7 +89,7 @@ verifyResult() {
   verify('Un autre message avec un seul paramètre hello');
   verify('Caractères qui doivent être échapper, par exemple barres \\ '
       'dollars \${ (les accolades sont ok), et xml/html réservés <& et '
-      'des citations \" '
+      'des citations " '
       'avec quelques paramètres ainsi 1, 2, et 3');
   verify('Cette message prend plusiers lignes.');
   verify('1, b, [c, d]');
@@ -161,7 +161,7 @@ verifyResult() {
   verify('Eine weitere Meldung mit dem Parameter hello');
   verify('Zeichen, die Flucht benötigen, zB Schrägstriche \\ Dollar '
       '\${ (geschweiften Klammern sind ok) und xml reservierte Zeichen <& und '
-      'Zitate \" Parameter 1, 2 und 3');
+      'Zitate " Parameter 1, 2 und 3');
   verify('Dieser String erstreckt sich über mehrere '
       'Zeilen erstrecken.');
   verify('1, b, [c, d]');

--- a/test/message_extraction/verify_messages.dart
+++ b/test/message_extraction/verify_messages.dart
@@ -1,16 +1,20 @@
 library verify_messages;
 
-import 'package:test/test.dart';
-
 import 'print_to_list.dart';
+
+void expectEquals(String actual, String expected) {
+  if (actual != expected) {
+    throw "expected '$expected' but got '$actual'";
+  }
+}
 
 void verifyResult() {
   Iterator<String> lineIterator;
 
-  void verify(String s) {
+  void verify(String str) {
     lineIterator.moveNext();
     var value = lineIterator.current;
-    expect(value, s);
+    expectEquals(value, str);
   }
 
   var expanded = lines.expand((line) => line.split('\n')).toList();
@@ -225,5 +229,8 @@ void verifyResult() {
   verify('Extraction skipped gender f');
   verify('Extraction skipped select specified Bob!');
   verify('This message should skip translation');
-  expect(lineIterator.moveNext(), isFalse);
+
+  if (lineIterator.moveNext()) {
+    throw 'too many elements: ${lineIterator.current}';
+  }
 }

--- a/test/message_extraction/verify_messages.dart
+++ b/test/message_extraction/verify_messages.dart
@@ -1,8 +1,8 @@
 library verify_messages;
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
-import "print_to_list.dart";
+import 'print_to_list.dart';
 
 verifyResult() {
   Iterator<String> lineIterator;
@@ -13,26 +13,26 @@ verifyResult() {
     expect(value, s);
   }
 
-  var expanded = lines.expand((line) => line.split("\n")).toList();
+  var expanded = lines.expand((line) => line.split('\n')).toList();
   lineIterator = expanded.iterator;
   verify('-------------------------------------------');
-  verify("Printing messages for en_US");
-  verify("This is a message");
-  verify("Another message with parameter hello");
-  verify("Characters that need escaping, e.g slashes \\ dollars \${ "
-      "(curly braces are ok) and xml reserved characters <& and "
-      "quotes \" parameters 1, 2, and 3");
-  verify("This string extends across multiple lines.");
-  verify("1, b, [c, d]");
+  verify('Printing messages for en_US');
+  verify('This is a message');
+  verify('Another message with parameter hello');
+  verify('Characters that need escaping, e.g slashes \\ dollars \${ '
+      '(curly braces are ok) and xml reserved characters <& and '
+      'quotes \" parameters 1, 2, and 3');
+  verify('This string extends across multiple lines.');
+  verify('1, b, [c, d]');
   verify('"So-called"');
-  verify("Cette chaîne est toujours traduit");
-  verify("Interpolation is tricky when it ends a sentence like this.");
-  verify("This comes from a method");
-  verify("This method is not a lambda");
-  verify("This comes from a static method");
-  verify("This is missing some translations");
-  verify("Ancient Greek hangman characters: 𐅆𐅇.");
-  verify("Escapable characters here: ");
+  verify('Cette chaîne est toujours traduit');
+  verify('Interpolation is tricky when it ends a sentence like this.');
+  verify('This comes from a method');
+  verify('This method is not a lambda');
+  verify('This comes from a static method');
+  verify('This is missing some translations');
+  verify('Ancient Greek hangman characters: 𐅆𐅇.');
+  verify('Escapable characters here: ');
 
   verify('Is zero plural?');
   verify('This is singular.');
@@ -84,26 +84,26 @@ verifyResult() {
   verify('-------------------------------------------');
 
   // French translations.
-  verify("Printing messages for fr");
+  verify('Printing messages for fr');
   verify("Il s'agit d'un message");
-  verify("Un autre message avec un seul paramètre hello");
-  verify("Caractères qui doivent être échapper, par exemple barres \\ "
-      "dollars \${ (les accolades sont ok), et xml/html réservés <& et "
-      "des citations \" "
-      "avec quelques paramètres ainsi 1, 2, et 3");
-  verify("Cette message prend plusiers lignes.");
-  verify("1, b, [c, d]");
+  verify('Un autre message avec un seul paramètre hello');
+  verify('Caractères qui doivent être échapper, par exemple barres \\ '
+      'dollars \${ (les accolades sont ok), et xml/html réservés <& et '
+      'des citations \" '
+      'avec quelques paramètres ainsi 1, 2, et 3');
+  verify('Cette message prend plusiers lignes.');
+  verify('1, b, [c, d]');
   verify('"Soi-disant"');
-  verify("Cette chaîne est toujours traduit");
+  verify('Cette chaîne est toujours traduit');
   verify("L'interpolation est délicate quand elle se termine une "
-      "phrase comme this.");
+      'phrase comme this.');
   verify("Cela vient d'une méthode");
   verify("Cette méthode n'est pas un lambda");
   verify("Cela vient d'une méthode statique");
-  verify("Ce manque certaines traductions");
-  verify("Anciens caractères grecs jeux du pendu: 𐅆𐅇.");
-  verify("Escapes: ");
-  verify("\r\f\b\t\v.");
+  verify('Ce manque certaines traductions');
+  verify('Anciens caractères grecs jeux du pendu: 𐅆𐅇.');
+  verify('Escapes: ');
+  verify('\r\f\b\t\v.');
 
   verify('Est-ce que nulle est pluriel?');
   verify('C\'est singulier');
@@ -156,27 +156,27 @@ verifyResult() {
   verify('-------------------------------------------');
 
   // German translations.
-  verify("Printing messages for de_DE");
-  verify("Dies ist eine Nachricht");
-  verify("Eine weitere Meldung mit dem Parameter hello");
-  verify("Zeichen, die Flucht benötigen, zB Schrägstriche \\ Dollar "
-      "\${ (geschweiften Klammern sind ok) und xml reservierte Zeichen <& und "
-      "Zitate \" Parameter 1, 2 und 3");
-  verify("Dieser String erstreckt sich über mehrere "
-      "Zeilen erstrecken.");
-  verify("1, b, [c, d]");
+  verify('Printing messages for de_DE');
+  verify('Dies ist eine Nachricht');
+  verify('Eine weitere Meldung mit dem Parameter hello');
+  verify('Zeichen, die Flucht benötigen, zB Schrägstriche \\ Dollar '
+      '\${ (geschweiften Klammern sind ok) und xml reservierte Zeichen <& und '
+      'Zitate \" Parameter 1, 2 und 3');
+  verify('Dieser String erstreckt sich über mehrere '
+      'Zeilen erstrecken.');
+  verify('1, b, [c, d]');
   verify('"Sogenannt"');
   // This is correct, the message is forced to French, even in a German locale.
-  verify("Cette chaîne est toujours traduit");
+  verify('Cette chaîne est toujours traduit');
   verify(
-      "Interpolation ist schwierig, wenn es einen Satz wie dieser endet this.");
-  verify("Dies ergibt sich aus einer Methode");
-  verify("Diese Methode ist nicht eine Lambda");
-  verify("Dies ergibt sich aus einer statischen Methode");
-  verify("This is missing some translations");
-  verify("Antike griechische Galgenmännchen Zeichen: 𐅆𐅇");
-  verify("Escapes: ");
-  verify("\r\f\b\t\v.");
+      'Interpolation ist schwierig, wenn es einen Satz wie dieser endet this.');
+  verify('Dies ergibt sich aus einer Methode');
+  verify('Diese Methode ist nicht eine Lambda');
+  verify('Dies ergibt sich aus einer statischen Methode');
+  verify('This is missing some translations');
+  verify('Antike griechische Galgenmännchen Zeichen: 𐅆𐅇');
+  verify('Escapes: ');
+  verify('\r\f\b\t\v.');
 
   verify('Ist Null Plural?');
   verify('Dies ist einmalig');

--- a/test/message_extraction/verify_messages.dart
+++ b/test/message_extraction/verify_messages.dart
@@ -2,19 +2,15 @@ library verify_messages;
 
 import 'print_to_list.dart';
 
-void expectEquals(String actual, String expected) {
-  if (actual != expected) {
-    throw "expected '$expected' but got '$actual'";
-  }
-}
-
 void verifyResult() {
   Iterator<String> lineIterator;
 
-  void verify(String str) {
+  void verify(String expected) {
     lineIterator.moveNext();
-    var value = lineIterator.current;
-    expectEquals(value, str);
+    var actual = lineIterator.current;
+    if (expected != actual) {
+      throw "expected '$expected' but got '$actual'";
+    }
   }
 
   var expanded = lines.expand((line) => line.split('\n')).toList();
@@ -231,6 +227,6 @@ void verifyResult() {
   verify('This message should skip translation');
 
   if (lineIterator.moveNext()) {
-    throw 'too many elements: ${lineIterator.current}';
+    throw 'more messages than expected';
   }
 }

--- a/test/message_extraction/verify_messages.dart
+++ b/test/message_extraction/verify_messages.dart
@@ -4,10 +4,10 @@ import 'package:test/test.dart';
 
 import 'print_to_list.dart';
 
-verifyResult() {
+void verifyResult() {
   Iterator<String> lineIterator;
 
-  verify(String s) {
+  void verify(String s) {
     lineIterator.moveNext();
     var value = lineIterator.current;
     expect(value, s);

--- a/test/two_components/app_messages_all.dart
+++ b/test/two_components/app_messages_all.dart
@@ -30,13 +30,13 @@ Future<bool> initializeMessages(String localeName) async {
       localeName, (locale) => _deferredLibraries[locale] != null,
       onFailure: (_) => null);
   if (availableLocale == null) {
-    return new Future.value(false);
+    return Future.value(false);
   }
   var lib = _deferredLibraries[availableLocale];
-  await (lib == null ? new Future.value(false) : lib());
-  initializeInternalMessageLookup(() => new CompositeMessageLookup());
+  await (lib == null ? Future.value(false) : lib());
+  initializeInternalMessageLookup(() => CompositeMessageLookup());
   messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
-  return new Future.value(true);
+  return Future.value(true);
 }
 
 bool _messagesExistFor(String locale) {

--- a/test/two_components/app_messages_fr.dart
+++ b/test/two_components/app_messages_fr.dart
@@ -16,11 +16,11 @@ typedef MessageIfAbsent = Function(String message_str, List args);
 
 class MessageLookup extends MessageLookupByLibrary {
   @override
-  get localeName => 'fr';
+  String get localeName => 'fr';
 
   @override
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static _notInlinedMessages(_) => {
+  static Map<String, String Function()> _notInlinedMessages(_) => {
         'Hello from application':
             MessageLookupByLibrary.simpleMessage("Bonjour de l'application")
       };

--- a/test/two_components/app_messages_fr.dart
+++ b/test/two_components/app_messages_fr.dart
@@ -15,8 +15,10 @@ final _keepAnalysisHappy = Intl.defaultLocale;
 typedef MessageIfAbsent = Function(String message_str, List args);
 
 class MessageLookup extends MessageLookupByLibrary {
+  @override
   get localeName => 'fr';
 
+  @override
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => {
         'Hello from application':

--- a/test/two_components/app_messages_fr.dart
+++ b/test/two_components/app_messages_fr.dart
@@ -22,6 +22,6 @@ class MessageLookup extends MessageLookupByLibrary {
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => {
         'Hello from application':
-            MessageLookupByLibrary.simpleMessage("Bonjour de l\'application")
+            MessageLookupByLibrary.simpleMessage("Bonjour de l'application")
       };
 }

--- a/test/two_components/app_messages_fr.dart
+++ b/test/two_components/app_messages_fr.dart
@@ -6,7 +6,7 @@
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 
-final messages = new MessageLookup();
+final messages = MessageLookup();
 
 // ignore: unused_element
 final _keepAnalysisHappy = Intl.defaultLocale;
@@ -19,7 +19,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => {
-        "Hello from application":
+        'Hello from application':
             MessageLookupByLibrary.simpleMessage("Bonjour de l\'application")
       };
 }

--- a/test/two_components/component.dart
+++ b/test/two_components/component.dart
@@ -4,8 +4,8 @@
 
 /// A component which should have its own separate messages, with their own
 /// translations.
-
 import 'package:intl/intl.dart';
+
 import 'component_messages_all.dart';
 
 /// We can just define a normal message, in which case we'll want to pick up

--- a/test/two_components/component.dart
+++ b/test/two_components/component.dart
@@ -5,20 +5,20 @@
 /// A component which should have its own separate messages, with their own
 /// translations.
 
-import "package:intl/intl.dart";
-import "component_messages_all.dart";
+import 'package:intl/intl.dart';
+import 'component_messages_all.dart';
 
 /// We can just define a normal message, in which case we'll want to pick up
 /// our special locale from the zone variable.
-String _message1() => Intl.message("Hello from component", desc: 'hi');
+String _message1() => Intl.message('Hello from component', desc: 'hi');
 
 /// Or we can explicitly code our locale.
-String _message2() => Intl.message("Explicit locale",
-    name: "_message2", desc: "message two", locale: myParticularLocale);
+String _message2() => Intl.message('Explicit locale',
+    name: '_message2', desc: 'message two', locale: myParticularLocale);
 
-String get myParticularLocale => "${Intl.defaultLocale}_$mySuffix";
+String get myParticularLocale => '${Intl.defaultLocale}_$mySuffix';
 
-const mySuffix = "xyz123";
+const mySuffix = 'xyz123';
 
 /// We can wrap all of our top-level API calls in a zone that stores the locale.
 dynamic componentApiFunction() => Intl.withLocale(myParticularLocale, _message1);

--- a/test/two_components/component.dart
+++ b/test/two_components/component.dart
@@ -10,19 +10,19 @@ import "component_messages_all.dart";
 
 /// We can just define a normal message, in which case we'll want to pick up
 /// our special locale from the zone variable.
-_message1() => Intl.message("Hello from component", desc: 'hi');
+String _message1() => Intl.message("Hello from component", desc: 'hi');
 
 /// Or we can explicitly code our locale.
-_message2() => Intl.message("Explicit locale",
+String _message2() => Intl.message("Explicit locale",
     name: "_message2", desc: "message two", locale: myParticularLocale);
 
-get myParticularLocale => "${Intl.defaultLocale}_$mySuffix";
+String get myParticularLocale => "${Intl.defaultLocale}_$mySuffix";
 
 const mySuffix = "xyz123";
 
 /// We can wrap all of our top-level API calls in a zone that stores the locale.
-componentApiFunction() => Intl.withLocale(myParticularLocale, _message1);
+dynamic componentApiFunction() => Intl.withLocale(myParticularLocale, _message1);
 
-directApiCall() => _message2();
+dynamic directApiCall() => _message2();
 
-initComponent() async => await initializeMessages(myParticularLocale);
+Future<bool> initComponent() async => await initializeMessages(myParticularLocale);

--- a/test/two_components/component.dart
+++ b/test/two_components/component.dart
@@ -21,8 +21,10 @@ String get myParticularLocale => '${Intl.defaultLocale}_$mySuffix';
 const mySuffix = 'xyz123';
 
 /// We can wrap all of our top-level API calls in a zone that stores the locale.
-dynamic componentApiFunction() => Intl.withLocale(myParticularLocale, _message1);
+dynamic componentApiFunction() =>
+    Intl.withLocale(myParticularLocale, _message1);
 
 dynamic directApiCall() => _message2();
 
-Future<bool> initComponent() async => await initializeMessages(myParticularLocale);
+Future<bool> initComponent() async =>
+    await initializeMessages(myParticularLocale);

--- a/test/two_components/component_messages_all.dart
+++ b/test/two_components/component_messages_all.dart
@@ -30,13 +30,13 @@ Future<bool> initializeMessages(String localeName) async {
       localeName, (locale) => _deferredLibraries[locale] != null,
       onFailure: (_) => null);
   if (availableLocale == null) {
-    return new Future.value(false);
+    return Future.value(false);
   }
   var lib = _deferredLibraries[availableLocale];
-  await (lib == null ? new Future.value(false) : lib());
-  initializeInternalMessageLookup(() => new CompositeMessageLookup());
+  await (lib == null ? Future.value(false) : lib());
+  initializeInternalMessageLookup(() => CompositeMessageLookup());
   messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
-  return new Future.value(true);
+  return Future.value(true);
 }
 
 bool _messagesExistFor(String locale) {

--- a/test/two_components/component_messages_fr_xyz123.dart
+++ b/test/two_components/component_messages_fr_xyz123.dart
@@ -6,7 +6,7 @@
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 
-final messages = new MessageLookup();
+final messages = MessageLookup();
 
 // ignore: unused_element
 final _keepAnalysisHappy = Intl.defaultLocale;
@@ -19,8 +19,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => {
-        "Hello from component":
-            MessageLookupByLibrary.simpleMessage("Bonjour du composant"),
-        "_message2": MessageLookupByLibrary.simpleMessage("Locale explicite")
+        'Hello from component':
+            MessageLookupByLibrary.simpleMessage('Bonjour du composant'),
+        '_message2': MessageLookupByLibrary.simpleMessage('Locale explicite')
       };
 }

--- a/test/two_components/component_messages_fr_xyz123.dart
+++ b/test/two_components/component_messages_fr_xyz123.dart
@@ -16,11 +16,11 @@ typedef MessageIfAbsent = Function(String message_str, List args);
 
 class MessageLookup extends MessageLookupByLibrary {
   @override
-  get localeName => 'fr_xyz123';
+  String get localeName => 'fr_xyz123';
 
   @override
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static _notInlinedMessages(_) => {
+  static Map<String, String Function()> _notInlinedMessages(_) => {
         'Hello from component':
             MessageLookupByLibrary.simpleMessage('Bonjour du composant'),
         '_message2': MessageLookupByLibrary.simpleMessage('Locale explicite')

--- a/test/two_components/component_messages_fr_xyz123.dart
+++ b/test/two_components/component_messages_fr_xyz123.dart
@@ -15,8 +15,10 @@ final _keepAnalysisHappy = Intl.defaultLocale;
 typedef MessageIfAbsent = Function(String message_str, List args);
 
 class MessageLookup extends MessageLookupByLibrary {
+  @override
   get localeName => 'fr_xyz123';
 
+  @override
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => {
         'Hello from component':

--- a/test/two_components/initialize_child_test.dart
+++ b/test/two_components/initialize_child_test.dart
@@ -8,16 +8,16 @@
 /// convenient to put it here because there's already a hard-coded
 /// message here.
 
-import "package:intl/intl.dart";
-import "package:test/test.dart";
+import 'package:intl/intl.dart';
+import 'package:test/test.dart';
 
-import "app_messages_all.dart";
-import "main_app_test.dart";
+import 'app_messages_all.dart';
+import 'main_app_test.dart';
 
 main() {
-  test("Initialize sub-locale", () async {
-    await initializeMessages("fr_FR");
+  test('Initialize sub-locale', () async {
+    await initializeMessages('fr_FR');
     Intl.withLocale(
-        "fr_FR", () => expect(appMessage(), "Bonjour de l'application"));
+        'fr_FR', () => expect(appMessage(), "Bonjour de l'application"));
   });
 }

--- a/test/two_components/initialize_child_test.dart
+++ b/test/two_components/initialize_child_test.dart
@@ -18,6 +18,6 @@ main() {
   test("Initialize sub-locale", () async {
     await initializeMessages("fr_FR");
     Intl.withLocale(
-        "fr_FR", () => expect(appMessage(), "Bonjour de l\'application"));
+        "fr_FR", () => expect(appMessage(), "Bonjour de l'application"));
   });
 }

--- a/test/two_components/initialize_child_test.dart
+++ b/test/two_components/initialize_child_test.dart
@@ -14,7 +14,7 @@ import 'package:test/test.dart';
 import 'app_messages_all.dart';
 import 'main_app_test.dart';
 
-main() {
+void main() {
   test('Initialize sub-locale', () async {
     await initializeMessages('fr_FR');
     Intl.withLocale(

--- a/test/two_components/initialize_child_test.dart
+++ b/test/two_components/initialize_child_test.dart
@@ -7,7 +7,6 @@
 /// This is not actually related to the two components testing, but it's
 /// convenient to put it here because there's already a hard-coded
 /// message here.
-
 import 'package:intl/intl.dart';
 import 'package:test/test.dart';
 

--- a/test/two_components/main_app_test.dart
+++ b/test/two_components/main_app_test.dart
@@ -10,7 +10,7 @@ import "package:test/test.dart";
 import "app_messages_all.dart";
 import "component.dart" as component;
 
-appMessage() => Intl.message("Hello from application", desc: 'hi');
+String appMessage() => Intl.message("Hello from application", desc: 'hi');
 
 main() async {
   Intl.defaultLocale = "fr";

--- a/test/two_components/main_app_test.dart
+++ b/test/two_components/main_app_test.dart
@@ -4,21 +4,21 @@
 
 /// An application using the component
 
-import "package:intl/intl.dart";
-import "package:test/test.dart";
+import 'package:intl/intl.dart';
+import 'package:test/test.dart';
 
-import "app_messages_all.dart";
-import "component.dart" as component;
+import 'app_messages_all.dart';
+import 'component.dart' as component;
 
-String appMessage() => Intl.message("Hello from application", desc: 'hi');
+String appMessage() => Intl.message('Hello from application', desc: 'hi');
 
 main() async {
-  Intl.defaultLocale = "fr";
-  await initializeMessages("fr");
+  Intl.defaultLocale = 'fr';
+  await initializeMessages('fr');
   await component.initComponent();
-  test("Component has its own messages", () {
+  test('Component has its own messages', () {
     expect(appMessage(), "Bonjour de l'application");
-    expect(component.componentApiFunction(), "Bonjour du composant");
-    expect(component.directApiCall(), "Locale explicite");
+    expect(component.componentApiFunction(), 'Bonjour du composant');
+    expect(component.directApiCall(), 'Locale explicite');
   });
 }

--- a/test/two_components/main_app_test.dart
+++ b/test/two_components/main_app_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// An application using the component
-
 import 'package:intl/intl.dart';
 import 'package:test/test.dart';
 

--- a/test/two_components/main_app_test.dart
+++ b/test/two_components/main_app_test.dart
@@ -12,7 +12,7 @@ import 'component.dart' as component;
 
 String appMessage() => Intl.message('Hello from application', desc: 'hi');
 
-main() async {
+void main() async {
   Intl.defaultLocale = 'fr';
   await initializeMessages('fr');
   await component.initComponent();

--- a/test/two_components/regenerate.sh
+++ b/test/two_components/regenerate.sh
@@ -2,7 +2,9 @@
 
 # Regenerate the messages Dart files.
 dart ../../bin/generate_from_arb.dart --generated-file-prefix=component_ \
+  --no-null-safety \
   component.dart component_translation_fr.arb
 
 dart ../../bin/generate_from_arb.dart --generated-file-prefix=app_ \
+  --no-null-safety \
   main_app_test.dart app_translation_getfromthelocale.arb

--- a/test/two_components/regenerate.sh
+++ b/test/two_components/regenerate.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
+
 # Regenerate the messages Dart files.
 dart ../../bin/generate_from_arb.dart --generated-file-prefix=component_ \
-component.dart component_translation_fr.arb
+  component.dart component_translation_fr.arb
+
 dart ../../bin/generate_from_arb.dart --generated-file-prefix=app_ \
-main_app_test.dart app_translation_getfromthelocale.arb
+  main_app_test.dart app_translation_getfromthelocale.arb


### PR DESCRIPTION
This PR enables many lints for this project; the general idea is to fill in some of the missing type information (this package is heavily dynamic) in order to provide a more reliable base for a null safety migration.

- upgrade to `package:lints/recommended.yaml`
- enable `always_declare_return_types` and `type_annotate_public_apis`
- address some of the violations from `avoid_dynamic_calls`

In addition, this PR exposes a `--null-safety` command line flag, to configure generating null safe code.

This PR will need to be vetted in google3 before landing. The next step up after that is likely a null safety migration.
