### PR TITLE
test across a wider range of SDKs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+# Dependabot configuration file.
+version: 2
+enable-beta-ecosystems: true
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,26 +4,33 @@ on:
   schedule:
     # “At 00:00 (UTC) on Sunday.”
     - cron: '0 0 * * 0'
-  pull_request:
   push:
-    branches:
-      - master
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    container:
-      image:  google/dart:dev
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        sdk: [2.12.2, stable, dev]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: ${{ matrix.sdk }}
 
-      - name: dart pub get
+      - name: Install dependencies
         run: dart pub get
 
-      - name: dart analyze
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze project source
         run: dart analyze --fatal-infos
 
-      - name: dart test
+      - name: Run tests
         run: dart test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         sdk: [2.14.0, stable, dev]
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -26,8 +27,9 @@ jobs:
       - name: Install dependencies
         run: dart pub get
 
-      - name: Verify formatting
-        run: dart format --output=none --set-exit-if-changed .
+      # TODO(devoncarew): Re-enable this after more refactoring of the repo.
+      # - name: Verify formatting
+      #   run: dart format --output=none --set-exit-if-changed .
 
       - name: Analyze project source
         run: dart analyze --fatal-infos

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,8 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TODO(devoncarew): Re-enable; there are currently 9 failing tests on
+        # Windows.
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         sdk: [2.14.0, stable, dev]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    name: build on ${{ matrix.os }} for ${{ matrix.sdk }}
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -24,15 +29,15 @@ jobs:
         with:
           sdk: ${{ matrix.sdk }}
 
-      - name: Install dependencies
+      - name: dart pub get
         run: dart pub get
 
       # TODO(devoncarew): Re-enable this after more refactoring of the repo.
-      # - name: Verify formatting
+      # - name: dart format
       #   run: dart format --output=none --set-exit-if-changed .
 
-      - name: Analyze project source
+      - name: dart analyze
         run: dart analyze --fatal-infos
 
-      - name: Run tests
+      - name: dart test
         run: dart test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        sdk: [2.14.0, stable, dev]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [2.12.2, stable, dev]
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b


### PR DESCRIPTION
Refactor the github actions setup:
- test across a wider range of SDKs
- use the `dart-lang/setup-dart` action
- ask dependabot to send us periodic updates to the actions versions