### PR TITLE
Fixes wrong parameter type in function `recreateIntlObjects` that causes generate_from_arb to exit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: "Bug: "
+labels: bug
+---
+
+**Description**
+A clear and concise description of what the bug is.
+
+**Steps To Reproduce**
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional Context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature request
+about: A new feature to be implemented
+label: enhancement
+---
+
+**Type of Issue**  
+- [ ] New Feature Implementation
+- [ ] Addition / Enhancement / Improvement
+
+**Type of Work**  
+- [ ] Screen  
+- [ ] Widget/Component  
+- [ ] Business Logic (Service, Repository, BloC)  
+- [ ] Backend Service
+- [ ] DevOps
+- [ ] Documentation
+
+**Description**  
+*Describe in simple sentences the functionality*  
+
+As a [type of user],  
+I want to [perform an action],  
+so that I can [achieve a goal].  
+
+**Actionable Tasks**  
+- [ ] Implement a Cubit/BloC for [action] with states [...] and methods [...]  
+- [ ] Implement Widget to trigger [action]  
+- [ ] Implement Widget to display [result of the action]  
+- [ ] ...
+
+**Acceptance criteria**  
+- [ ] Screen should render the initial UI properly  
+- [ ] After [action is performed] state should change  
+- [ ] New UI is properly rendered  
+- [ ] ...

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,12 @@
+---
+name: Question
+about: Create a question
+title: "Question: "
+labels: question
+---
+
+**Question**  
+Describe your question with as many details as possible and in concise, clear language.
+
+**Associted Issues, Modules, etc.**  
+Give more context, what this question is related with.

--- a/bin/generate_from_arb.dart
+++ b/bin/generate_from_arb.dart
@@ -225,12 +225,14 @@ void generateLocaleFile(String locale, List<Map> localeData, String targetDir,
 /// things that are messages, we expect [id] not to start with "@" and
 /// [data] to be a String. For metadata we expect [id] to start with "@"
 /// and [data] to be a Map or null. For metadata we return null.
-BasicTranslatedMessage recreateIntlObjects(String id, String data) {
+BasicTranslatedMessage recreateIntlObjects(String id, dynamic data) {
   if (id.startsWith('@')) return null;
   if (data == null) return null;
   var parsed = pluralAndGenderParser.parse(data).value;
   if (parsed is LiteralString && parsed.string.isEmpty) {
     parsed = plainParser.parse(data).value;
+  } else {
+    return null;
   }
   return BasicTranslatedMessage(id, parsed);
 }


### PR DESCRIPTION
In some of my .arb files, I had the issue, that the `@` at the beginning of a key resulted in an error:
```
Unhandled exception:
type '_InternalLinkedHashMap<String, dynamic>' is not a subtype of type 'String'
```

Here is an example of the .arb:
```
...
"super_nice_key": "Super Nice Key",
"@super_nice_key": {
        "type": "text"
},
...
```

Why the problem exists:
The values in the json file, which here are `"Super Nice Key"`, or `{ "type": "text" }`, are not always decoded as type `String`, but when passed to the function `recreateIntlObjects(String id, String data)` as `data`, they are expected to be always of type `String`.

What I did is, I changed the type of parameter  `data` to `dynamic`, so it supports the decoded Map from the arb file too.

BTW inside the function, there was already an explicit type check for `LiteralString`, so `dynamic` is not removing any type safety here.  