### PR TITLE
Ignore all lints in generated code

### DIFF
--- a/example/lib/generated/messages_all_locales.dart
+++ b/example/lib/generated/messages_all_locales.dart
@@ -2,12 +2,8 @@
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
 
-// Ignore issues from commonly used lints in this file.
-// ignore_for_file:implementation_imports, file_names
-// ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
-// ignore_for_file:argument_type_not_assignable, invalid_assignment
-// ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
-// ignore_for_file:comment_references
+// Ignore issues from any lints in this file.
+// ignore_for_file: type=lint
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';

--- a/example/lib/generated/messages_all_locales.dart
+++ b/example/lib/generated/messages_all_locales.dart
@@ -3,7 +3,7 @@
 // delegating to the appropriate library.
 
 // Ignore issues from any lints in this file.
-// ignore_for_file: type=lint
+// ignore_for_file: type=lint, unused_import
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';

--- a/example/lib/generated/messages_de.dart
+++ b/example/lib/generated/messages_de.dart
@@ -4,7 +4,7 @@
 // function name.
 
 // Ignore issues from any lints in this file.
-// ignore_for_file: type=lint
+// ignore_for_file: type=lint, unused_import
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';

--- a/example/lib/generated/messages_de.dart
+++ b/example/lib/generated/messages_de.dart
@@ -3,11 +3,8 @@
 // messages from the main program should be duplicated here with the same
 // function name.
 
-// Ignore issues from commonly used lints in this file.
-// ignore_for_file:unnecessary_brace_in_string_interps
-// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
-// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
-// ignore_for_file:unused_import, file_names
+// Ignore issues from any lints in this file.
+// ignore_for_file: type=lint
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';

--- a/example/lib/generated/messages_de_CH.dart
+++ b/example/lib/generated/messages_de_CH.dart
@@ -4,7 +4,7 @@
 // function name.
 
 // Ignore issues from any lints in this file.
-// ignore_for_file: type=lint
+// ignore_for_file: type=lint, unused_import
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';

--- a/example/lib/generated/messages_de_CH.dart
+++ b/example/lib/generated/messages_de_CH.dart
@@ -3,11 +3,8 @@
 // messages from the main program should be duplicated here with the same
 // function name.
 
-// Ignore issues from commonly used lints in this file.
-// ignore_for_file:unnecessary_brace_in_string_interps
-// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
-// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
-// ignore_for_file:unused_import, file_names
+// Ignore issues from any lints in this file.
+// ignore_for_file: type=lint
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';

--- a/example/lib/generated/messages_en.dart
+++ b/example/lib/generated/messages_en.dart
@@ -4,7 +4,7 @@
 // function name.
 
 // Ignore issues from any lints in this file.
-// ignore_for_file: type=lint
+// ignore_for_file: type=lint, unused_import
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';

--- a/example/lib/generated/messages_en.dart
+++ b/example/lib/generated/messages_en.dart
@@ -3,11 +3,8 @@
 // messages from the main program should be duplicated here with the same
 // function name.
 
-// Ignore issues from commonly used lints in this file.
-// ignore_for_file:unnecessary_brace_in_string_interps
-// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
-// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
-// ignore_for_file:unused_import, file_names
+// Ignore issues from any lints in this file.
+// ignore_for_file: type=lint
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';

--- a/example/lib/generated/messages_es.dart
+++ b/example/lib/generated/messages_es.dart
@@ -4,7 +4,7 @@
 // function name.
 
 // Ignore issues from any lints in this file.
-// ignore_for_file: type=lint
+// ignore_for_file: type=lint, unused_import
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';

--- a/example/lib/generated/messages_es.dart
+++ b/example/lib/generated/messages_es.dart
@@ -3,11 +3,8 @@
 // messages from the main program should be duplicated here with the same
 // function name.
 
-// Ignore issues from commonly used lints in this file.
-// ignore_for_file:unnecessary_brace_in_string_interps
-// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
-// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
-// ignore_for_file:unused_import, file_names
+// Ignore issues from any lints in this file.
+// ignore_for_file: type=lint
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -186,7 +186,7 @@ class MessageGeneration {
 // function name.
 $languageTag
 // Ignore issues from any lints in this file.
-// ignore_for_file: type=lint
+// ignore_for_file: type=lint, unused_import
 
 import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';
@@ -268,7 +268,7 @@ ${releaseMode ? overrideLookup() : ''}''';
 // delegating to the appropriate library.
 $languageTag
 // Ignore issues from any lints in this file.
-// ignore_for_file: type=lint
+// ignore_for_file: type=lint, unused_import
 
 import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';

--- a/lib/generate_localized.dart
+++ b/lib/generate_localized.dart
@@ -185,11 +185,8 @@ class MessageGeneration {
 // messages from the main program should be duplicated here with the same
 // function name.
 $languageTag
-// Ignore issues from commonly used lints in this file.
-// ignore_for_file:unnecessary_brace_in_string_interps
-// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
-// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
-// ignore_for_file:unused_import, file_names
+// Ignore issues from any lints in this file.
+// ignore_for_file: type=lint
 
 import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';
@@ -270,12 +267,8 @@ ${releaseMode ? overrideLookup() : ''}''';
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
 $languageTag
-// Ignore issues from commonly used lints in this file.
-// ignore_for_file:implementation_imports, file_names
-// ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
-// ignore_for_file:argument_type_not_assignable, invalid_assignment
-// ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
-// ignore_for_file:comment_references
+// Ignore issues from any lints in this file.
+// ignore_for_file: type=lint
 
 import 'package:$intlImportPath/intl.dart';
 import 'package:$intlImportPath/message_lookup_by_library.dart';


### PR DESCRIPTION
As proposed in https://github.com/dart-lang/intl_translation/pull/103#issuecomment-1020155932, which also points to a similar issue in mockito, ignore all lints in the generated code. I am not 100% sure about this, but I think it makes sense.