### PR TITLE
Mention Lyrebird in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ dart run intl_translation:extract_to_arb --output-dir=target/directory
 
 This will produce a file `intl_messages.arb` with the messages from all of these
 programs. This is an [ARB][arb] format file which can be used for input to
-translation tools like [Localizely][localizely]. The resulting translations can
+translation tools like [Localizely][localizely] or [Lyrebird][lyrebird]. The resulting translations can
 be used to generate a set of libraries using the `generate_from_arb.dart`
 program.
 
@@ -58,3 +58,4 @@ data is available.
 [arb]:
   https://github.com/google/app-resource-bundle/wiki/ApplicationResourceBundleSpecification
 [localizely]: https://localizely.com/
+[lyrebird]: https://lyrebird.dev/


### PR DESCRIPTION
Dear Dart team,

Over the past couple of weeks I created a visual editor for ARB localization files called [Lyrebird](https://lyrebird.dev), specifically designed to work with the `intl` and `intl_translation` packages. I believe it to be of great use to any Dart or Flutter developer using ARB files, as I always wished this project would exist.

The large number of likes compared to the low popularity score on [pub.dev](https://pub.dev/packages/lyrebird) suggests that it is well received by the few people who saw my Reddit post, but is lacking widespread awareness. Because of this, and because I saw Localizely being mentioned in this project's `README.md`, I humbly request a shout-out of Lyrebird so that more people can profit from my work.

Kind regards,
Julien